### PR TITLE
Implement logging and remove wlroots dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,6 @@ channel or shoot an email to sir@cmpwn.com for advice.
 Install dependencies:
 
 * meson \*
-* [wlroots](https://github.com/swaywm/wlroots)
 * wayland
 * wayland-protocols \*
 * pango

--- a/background-image.c
+++ b/background-image.c
@@ -1,8 +1,8 @@
 #include <assert.h>
 #include <stdbool.h>
-#include <wlr/util/log.h>
 #include "background-image.h"
 #include "cairo.h"
+#include "log.h"
 
 enum background_mode parse_background_mode(const char *mode) {
 	if (strcmp(mode, "stretch") == 0) {
@@ -18,7 +18,7 @@ enum background_mode parse_background_mode(const char *mode) {
 	} else if (strcmp(mode, "solid_color") == 0) {
 		return BACKGROUND_MODE_SOLID_COLOR;
 	}
-	wlr_log(WLR_ERROR, "Unsupported background mode: %s", mode);
+	swaylock_log(LOG_ERROR, "Unsupported background mode: %s", mode);
 	return BACKGROUND_MODE_INVALID;
 }
 
@@ -28,7 +28,7 @@ cairo_surface_t *load_background_image(const char *path) {
 	GError *err = NULL;
 	GdkPixbuf *pixbuf = gdk_pixbuf_new_from_file(path, &err);
 	if (!pixbuf) {
-		wlr_log(WLR_ERROR, "Failed to load background image (%s).",
+		swaylock_log(LOG_ERROR, "Failed to load background image (%s).",
 				err->message);
 		return false;
 	}
@@ -38,11 +38,11 @@ cairo_surface_t *load_background_image(const char *path) {
 	image = cairo_image_surface_create_from_png(path);
 #endif // HAVE_GDK_PIXBUF
 	if (!image) {
-		wlr_log(WLR_ERROR, "Failed to read background image.");
+		swaylock_log(LOG_ERROR, "Failed to read background image.");
 		return NULL;
 	}
 	if (cairo_surface_status(image) != CAIRO_STATUS_SUCCESS) {
-		wlr_log(WLR_ERROR, "Failed to read background image: %s."
+		swaylock_log(LOG_ERROR, "Failed to read background image: %s."
 #if !HAVE_GDK_PIXBUF
 				"\nSway was compiled without gdk_pixbuf support, so only"
 				"\nPNG images can be loaded. This is the likely cause."

--- a/include/log.h
+++ b/include/log.h
@@ -1,0 +1,36 @@
+#ifndef _SWAYLOCK_LOG_H
+#define _SWAYLOCK_LOG_H
+
+#include <stdarg.h>
+#include <string.h>
+#include <errno.h>
+
+enum log_importance {
+	LOG_SILENT = 0,
+	LOG_ERROR = 1,
+	LOG_INFO = 2,
+	LOG_DEBUG = 3,
+	LOG_IMPORTANCE_LAST,
+};
+
+void swaylock_log_init(enum log_importance verbosity);
+
+#ifdef __GNUC__
+#define _ATTRIB_PRINTF(start, end) __attribute__((format(printf, start, end)))
+#else
+#define _ATTRIB_PRINTF(start, end)
+#endif
+
+void _swaylock_log(enum log_importance verbosity, const char *format, ...)
+	_ATTRIB_PRINTF(2, 3);
+
+const char *_swaylock_strip_path(const char *filepath);
+
+#define swaylock_log(verb, fmt, ...) \
+	_swaylock_log(verb, "[%s:%d] " fmt, _swaylock_strip_path(__FILE__), \
+			__LINE__, ##__VA_ARGS__)
+
+#define swaylock_log_errno(verb, fmt, ...) \
+	swaylock_log(verb, fmt ": %s", ##__VA_ARGS__, strerror(errno))
+
+#endif

--- a/log.c
+++ b/log.c
@@ -1,0 +1,68 @@
+#define _POSIX_C_SOURCE 199506L
+#include <errno.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <unistd.h>
+#include "log.h"
+
+static enum log_importance log_importance = LOG_ERROR;
+
+static const char *verbosity_colors[] = {
+	[LOG_SILENT] = "",
+	[LOG_ERROR ] = "\x1B[1;31m",
+	[LOG_INFO  ] = "\x1B[1;34m",
+	[LOG_DEBUG ] = "\x1B[1;30m",
+};
+
+void swaylock_log_init(enum log_importance verbosity) {
+	if (verbosity < LOG_IMPORTANCE_LAST) {
+		log_importance = verbosity;
+	}
+}
+
+void _swaylock_log(enum log_importance verbosity, const char *fmt, ...) {
+	if (verbosity > log_importance) {
+		return;
+	}
+
+	va_list args;
+	va_start(args, fmt);
+
+	// prefix the time to the log message
+	struct tm result;
+	time_t t = time(NULL);
+	struct tm *tm_info = localtime_r(&t, &result);
+	char buffer[26];
+
+	// generate time prefix
+	strftime(buffer, sizeof(buffer), "%F %T - ", tm_info);
+	fprintf(stderr, "%s", buffer);
+
+	unsigned c = (verbosity < LOG_IMPORTANCE_LAST)
+		? verbosity : LOG_IMPORTANCE_LAST - 1;
+
+	if (isatty(STDERR_FILENO)) {
+		fprintf(stderr, "%s", verbosity_colors[c]);
+	}
+
+	vfprintf(stderr, fmt, args);
+
+	if (isatty(STDERR_FILENO)) {
+		fprintf(stderr, "\x1B[0m");
+	}
+	fprintf(stderr, "\n");
+
+	va_end(args);
+}
+
+const char *_swaylock_strip_path(const char *filepath) {
+	if (*filepath == '.') {
+		while (*filepath == '.' || *filepath == '/') {
+			++filepath;
+		}
+	}
+	return filepath;
+}

--- a/loop.c
+++ b/loop.c
@@ -7,8 +7,8 @@
 #include <poll.h>
 #include <time.h>
 #include <unistd.h>
-#include <wlr/util/log.h>
 #include "list.h"
+#include "log.h"
 #include "loop.h"
 
 struct loop_fd_event {
@@ -34,7 +34,7 @@ struct loop {
 struct loop *loop_create(void) {
 	struct loop *loop = calloc(1, sizeof(struct loop));
 	if (!loop) {
-		wlr_log(WLR_ERROR, "Unable to allocate memory for loop");
+		swaylock_log(LOG_ERROR, "Unable to allocate memory for loop");
 		return NULL;
 	}
 	loop->fd_capacity = 10;
@@ -107,7 +107,7 @@ void loop_add_fd(struct loop *loop, int fd, short mask,
 		void (*callback)(int fd, short mask, void *data), void *data) {
 	struct loop_fd_event *event = calloc(1, sizeof(struct loop_fd_event));
 	if (!event) {
-		wlr_log(WLR_ERROR, "Unable to allocate memory for event");
+		swaylock_log(LOG_ERROR, "Unable to allocate memory for event");
 		return;
 	}
 	event->callback = callback;
@@ -129,7 +129,7 @@ struct loop_timer *loop_add_timer(struct loop *loop, int ms,
 		void (*callback)(void *data), void *data) {
 	struct loop_timer *timer = calloc(1, sizeof(struct loop_timer));
 	if (!timer) {
-		wlr_log(WLR_ERROR, "Unable to allocate memory for timer");
+		swaylock_log(LOG_ERROR, "Unable to allocate memory for timer");
 		return NULL;
 	}
 	timer->callback = callback;

--- a/meson.build
+++ b/meson.build
@@ -32,7 +32,6 @@ if is_freebsd
 	add_project_arguments('-D_C11_SOURCE', language: 'c')
 endif
 
-wlroots        = dependency('wlroots', fallback: ['wlroots', 'wlroots'])
 wayland_client = dependency('wayland-client')
 wayland_protos = dependency('wayland-protocols', version: '>=1.14')
 xkbcommon      = dependency('xkbcommon')
@@ -123,13 +122,13 @@ dependencies = [
     pangocairo,
     xkbcommon,
     wayland_client,
-    wlroots,
 ]
 
 sources = [
 	'background-image.c',
 	'cairo.c',
 	'list.c',
+	'log.c',
 	'loop.c',
 	'main.c',
 	'pango.c',

--- a/pam.c
+++ b/pam.c
@@ -5,7 +5,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
-#include <wlr/util/log.h>
+#include "log.h"
 #include "swaylock.h"
 
 void initialize_pw_backend(void) {
@@ -43,15 +43,15 @@ bool attempt_password(struct swaylock_password *pw) {
 	int pam_err;
 	if ((pam_err = pam_start("swaylock", username,
 					&local_conversation, &local_auth_handle)) != PAM_SUCCESS) {
-		wlr_log(WLR_ERROR, "PAM returned error %d", pam_err);
+		swaylock_log(LOG_ERROR, "PAM returned error %d", pam_err);
 	}
 	if ((pam_err = pam_authenticate(local_auth_handle, 0)) != PAM_SUCCESS) {
-		wlr_log(WLR_ERROR, "pam_authenticate failed");
+		swaylock_log(LOG_ERROR, "pam_authenticate failed");
 		goto fail;
 	}
 	// TODO: only call pam_end once we succeed at authing. refresh tokens beforehand
 	if ((pam_err = pam_end(local_auth_handle, pam_err)) != PAM_SUCCESS) {
-		wlr_log(WLR_ERROR, "pam_end failed");
+		swaylock_log(LOG_ERROR, "pam_end failed");
 		goto fail;
 	}
 	clear_password_buffer(pw);

--- a/pango.c
+++ b/pango.c
@@ -6,8 +6,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <wlr/util/log.h>
 #include "cairo.h"
+#include "log.h"
 
 static const char overflow[] = "[buffer overflow]";
 static const int max_chars = 16384;
@@ -70,8 +70,8 @@ PangoLayout *get_pango_layout(cairo_t *cairo, const char *font,
 			pango_layout_set_text(layout, buf, -1);
 			free(buf);
 		} else {
-			wlr_log(WLR_ERROR, "pango_parse_markup '%s' -> error %s", text,
-					error->message);
+			swaylock_log(LOG_ERROR, "pango_parse_markup '%s' -> error %s",
+					text, error->message);
 			g_error_free(error);
 			markup = false; // fallback to plain text
 		}

--- a/password.c
+++ b/password.c
@@ -4,11 +4,11 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
-#include <wlr/util/log.h>
 #include <xkbcommon/xkbcommon.h>
-#include "swaylock.h"
-#include "seat.h"
+#include "log.h"
 #include "loop.h"
+#include "seat.h"
+#include "swaylock.h"
 #include "unicode.h"
 
 void clear_password_buffer(struct swaylock_password *pw) {

--- a/seat.c
+++ b/seat.c
@@ -2,8 +2,8 @@
 #include <stdlib.h>
 #include <sys/mman.h>
 #include <unistd.h>
-#include <wlr/util/log.h>
 #include <xkbcommon/xkbcommon.h>
+#include "log.h"
 #include "swaylock.h"
 #include "seat.h"
 
@@ -12,13 +12,13 @@ static void keyboard_keymap(void *data, struct wl_keyboard *wl_keyboard,
 	struct swaylock_state *state = data;
 	if (format != WL_KEYBOARD_KEYMAP_FORMAT_XKB_V1) {
 		close(fd);
-		wlr_log(WLR_ERROR, "Unknown keymap format %d, aborting", format);
+		swaylock_log(LOG_ERROR, "Unknown keymap format %d, aborting", format);
 		exit(1);
 	}
 	char *map_shm = mmap(NULL, size, PROT_READ, MAP_SHARED, fd, 0);
 	if (map_shm == MAP_FAILED) {
 		close(fd);
-		wlr_log(WLR_ERROR, "Unable to initialize keymap shm, aborting");
+		swaylock_log(LOG_ERROR, "Unable to initialize keymap shm, aborting");
 		exit(1);
 	}
 	struct xkb_keymap *keymap = xkb_keymap_new_from_string(

--- a/swaylock.1.scd
+++ b/swaylock.1.scd
@@ -21,6 +21,9 @@ Locks your Wayland session.
 	All leading dashes should be omitted and the equals sign is required for
 	flags that take an argument.
 
+*-d, --debug*
+	Enable debugging output.
+
 *-e, --ignore-empty-password*
 	When an empty password is provided by the user, do not validate it.
 


### PR DESCRIPTION
Closes #1 

This implements a simpler version of the wlroots logger for swaylock.
With this logger, the dependency on wlroots can be dropped. This also
adds a debug flag and disables debugging output by default