### PR TITLE
Patched crash when spamming enter

### DIFF
--- a/password.c
+++ b/password.c
@@ -128,70 +128,71 @@ void swaylock_handle_key(struct swaylock_state *state,
 
 	static clock_t last_time_pressed_key = 0;
 	clock_t present_time = clock();
-
-	switch (keysym) {
-	case XKB_KEY_KP_Enter: /* fallthrough */
-	case XKB_KEY_Return:
-		submit_password(state);
-		break;
-	case XKB_KEY_Delete:
-	case XKB_KEY_BackSpace:
-		if (backspace(&state->password)) {
-			state->auth_state = AUTH_STATE_BACKSPACE;
-		} else {
-			state->auth_state = AUTH_STATE_CLEAR;
-		}
-		damage_state(state);
-		schedule_indicator_clear(state);
-		schedule_password_clear(state);
-		break;
-	case XKB_KEY_Escape:
-		clear_password_buffer(&state->password);
-		state->auth_state = AUTH_STATE_CLEAR;
-		damage_state(state);
-		schedule_indicator_clear(state);
-		break;
-	case XKB_KEY_Caps_Lock:
-	case XKB_KEY_Shift_L:
-	case XKB_KEY_Shift_R:
-	case XKB_KEY_Control_L:
-	case XKB_KEY_Control_R:
-	case XKB_KEY_Meta_L:
-	case XKB_KEY_Meta_R:
-	case XKB_KEY_Alt_L:
-	case XKB_KEY_Alt_R:
-	case XKB_KEY_Super_L:
-	case XKB_KEY_Super_R:
-		state->auth_state = AUTH_STATE_INPUT_NOP;
-		damage_state(state);
-		schedule_indicator_clear(state);
-		schedule_password_clear(state);
-		break;
-	case XKB_KEY_d:
-		if (state->xkb.control) {
+	if ((double)(present_time - last_time_pressed_key)/CLOCKS_PER_SEC >=0.000955) {
+		last_time_pressed_key = clock();
+		switch (keysym) {
+		case XKB_KEY_KP_Enter: /* fallthrough */
+		case XKB_KEY_Return:
 			submit_password(state);
 			break;
-		}
-		// fallthrough
-	case XKB_KEY_c: /* fallthrough */
-	case XKB_KEY_u:
-		if (state->xkb.control) {
+		case XKB_KEY_Delete:
+		case XKB_KEY_BackSpace:
+			if (backspace(&state->password)) {
+				state->auth_state = AUTH_STATE_BACKSPACE;
+			} else {
+				state->auth_state = AUTH_STATE_CLEAR;
+			}
+			damage_state(state);
+			schedule_indicator_clear(state);
+			schedule_password_clear(state);
+			break;
+		case XKB_KEY_Escape:
 			clear_password_buffer(&state->password);
 			state->auth_state = AUTH_STATE_CLEAR;
 			damage_state(state);
 			schedule_indicator_clear(state);
 			break;
-		}
-		// fallthrough
-	default:
-		if (codepoint && (double)(present_time - last_time_pressed_key)/CLOCKS_PER_SEC >=0.005455) {
-			append_ch(&state->password, codepoint);
-			state->auth_state = AUTH_STATE_INPUT;
+		case XKB_KEY_Caps_Lock:
+		case XKB_KEY_Shift_L:
+		case XKB_KEY_Shift_R:
+		case XKB_KEY_Control_L:
+		case XKB_KEY_Control_R:
+		case XKB_KEY_Meta_L:
+		case XKB_KEY_Meta_R:
+		case XKB_KEY_Alt_L:
+		case XKB_KEY_Alt_R:
+		case XKB_KEY_Super_L:
+		case XKB_KEY_Super_R:
+			state->auth_state = AUTH_STATE_INPUT_NOP;
 			damage_state(state);
 			schedule_indicator_clear(state);
 			schedule_password_clear(state);
-			last_time_pressed_key = clock();
+			break;
+		case XKB_KEY_d:
+			if (state->xkb.control) {
+				submit_password(state);
+				break;
+			}
+			// fallthrough
+		case XKB_KEY_c: /* fallthrough */
+		case XKB_KEY_u:
+			if (state->xkb.control) {
+				clear_password_buffer(&state->password);
+				state->auth_state = AUTH_STATE_CLEAR;
+				damage_state(state);
+				schedule_indicator_clear(state);
+				break;
+			}
+			// fallthrough
+		default:
+			if (codepoint) {
+				append_ch(&state->password, codepoint);
+				state->auth_state = AUTH_STATE_INPUT;
+				damage_state(state);
+				schedule_indicator_clear(state);
+				schedule_password_clear(state);
+			}
+			break;
 		}
-		break;
 	}
 }

--- a/password.c
+++ b/password.c
@@ -5,6 +5,8 @@
 #include <string.h>
 #include <unistd.h>
 #include <xkbcommon/xkbcommon.h>
+#include <time.h>
+#include <stdio.h>
 #include "log.h"
 #include "loop.h"
 #include "seat.h"
@@ -123,6 +125,10 @@ static void submit_password(struct swaylock_state *state) {
 
 void swaylock_handle_key(struct swaylock_state *state,
 		xkb_keysym_t keysym, uint32_t codepoint) {
+
+	static clock_t last_time_pressed_key = 0;
+	clock_t present_time = clock();
+
 	switch (keysym) {
 	case XKB_KEY_KP_Enter: /* fallthrough */
 	case XKB_KEY_Return:
@@ -178,12 +184,13 @@ void swaylock_handle_key(struct swaylock_state *state,
 		}
 		// fallthrough
 	default:
-		if (codepoint) {
+		if (codepoint && (double)(present_time - last_time_pressed_key)/CLOCKS_PER_SEC >=0.005455) {
 			append_ch(&state->password, codepoint);
 			state->auth_state = AUTH_STATE_INPUT;
 			damage_state(state);
 			schedule_indicator_clear(state);
 			schedule_password_clear(state);
+			last_time_pressed_key = clock();
 		}
 		break;
 	}


### PR DESCRIPTION
This is a quick fix for issue #10.
This patch prevents the crash but you still can't login from swaylock, you have to kill it from a tty
