### PR TITLE
Allow image file paths to contain colons

### DIFF
--- a/main.c
+++ b/main.c
@@ -364,12 +364,12 @@ static cairo_surface_t *select_image(struct swaylock_state *state,
 }
 
 static void load_image(char *arg, struct swaylock_state *state) {
-	// [<output>:]<path>
+	// [[<output>]:]<path>
 	struct swaylock_image *image = calloc(1, sizeof(struct swaylock_image));
 	char *separator = strchr(arg, ':');
 	if (separator) {
 		*separator = '\0';
-		image->output_name = strdup(arg);
+		image->output_name = separator == arg ? NULL : strdup(arg);
 		image->path = strdup(separator + 1);
 	} else {
 		image->output_name = NULL;
@@ -554,7 +554,7 @@ static int parse_options(int argc, char **argv, struct swaylock_state *state,
 			"Detach from the controlling terminal after locking.\n"
 		"  -h, --help                       "
 			"Show help message and quit.\n"
-		"  -i, --image [<output>:]<path>    "
+		"  -i, --image [[<output>]:]<path>  "
 			"Display the given image.\n"
 		"  -L, --disable-caps-lock-text     "
 			"Disable the Caps Lock text.\n"

--- a/swaylock.1.scd
+++ b/swaylock.1.scd
@@ -43,9 +43,10 @@ Locks your Wayland session.
 *-u, --no-unlock-indicator*
 	Disable the unlock indicator.
 
-*-i, --image* [<output>:]<path>
+*-i, --image* [[<output>]:]<path>
 	Display the given image, optionally only on the given output. Use -c to set
-	a background color.
+	a background color. If the path potentially contains a ':', prefix it with another
+	':' to prevent interpreting part of it as <output>.
 
 *-L, --disable-caps-lock-text*
 	Disable the Caps Lock Text.


### PR DESCRIPTION
Colon characters are allowed in file paths, so if an image file named 'foo:bar.png' is passed as an --image argument, it's currently parsed as image 'bar.png' on output 'foo'.

This fix allows the caller to pass the argument ':foo:bar.png' and treat an output of '' the same as NULL. This is assuming there will never be an output named '' however...