### PR TITLE
Replace old Sway references with swaylock

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,20 +13,18 @@ See the man page, `swaylock(1)`, for instructions on using swaylock.
 ## Release Signatures
 
 Releases are signed with [B22DA89A](http://pgp.mit.edu/pks/lookup?op=vindex&search=0x52CB6609B22DA89A)
-and published [on GitHub](https://github.com/swaywm/sway/releases). swaylock
+and published [on GitHub](https://github.com/swaywm/swaylock/releases). swaylock
 releases are managed independently of sway releases.
 
 ## Installation
 
 ### From Packages
 
-Sway is available in many distributions. Try installing the "swaylock" package
-for yours. If it's not available, check out [this wiki
-page](https://github.com/swaywm/sway/wiki/Unsupported-packages) for information
-on installation for your distributions.
+Swaylock is available in many distributions. Try installing the "swaylock"
+package for yours.
 
-If you're interested in packaging sway for your distribution, stop by the IRC
-channel or shoot an email to sir@cmpwn.com for advice.
+If you're interested in packaging swaylock for your distribution, stop by the
+IRC channel or shoot an email to sir@cmpwn.com for advice.
 
 ### Compiling from Source
 

--- a/main.c
+++ b/main.c
@@ -718,7 +718,7 @@ static int parse_options(int argc, char **argv, struct swaylock_state *state,
 			}
 			break;
 		case 'v':
-			fprintf(stdout, "swaylock version " SWAY_VERSION "\n");
+			fprintf(stdout, "swaylock version " SWAYLOCK_VERSION "\n");
 			exit(EXIT_SUCCESS);
 			break;
 		case LO_BS_HL_COLOR:

--- a/meson.build
+++ b/meson.build
@@ -47,7 +47,7 @@ git = find_program('git', required: false)
 scdoc = find_program('scdoc', required: false)
 wayland_scanner = find_program('wayland-scanner')
 
-version = get_option('sway-version')
+version = get_option('swaylock-version')
 if version != ''
 	version = '"@0@"'.format(version)
 else
@@ -59,7 +59,7 @@ else
 	git_branch = run_command([git.path(), 'rev-parse', '--abbrev-ref', 'HEAD']).stdout().strip()
 	version = '"@0@ (" __DATE__ ", branch \'@1@\')"'.format(git_commit_hash, git_branch)
 endif
-add_project_arguments('-DSWAY_VERSION=@0@'.format(version), language: 'c')
+add_project_arguments('-DSWAYLOCK_VERSION=@0@'.format(version), language: 'c')
 
 wl_protocol_dir = wayland_protos.get_pkgconfig_variable('pkgdatadir')
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,4 +1,4 @@
-option('sway-version', type : 'string', description: 'The version string reported in `sway --version`.')
+option('swaylock-version', type : 'string', description: 'The version string reported in `swaylock --version`.')
 option(
 	'pam',
 	type: 'combo',

--- a/swaylock.1.scd
+++ b/swaylock.1.scd
@@ -167,5 +167,5 @@ Locks your Wayland session.
 # AUTHORS
 
 Maintained by Drew DeVault <sir@cmpwn.com>, who is assisted by other open
-source contributors. For more information about sway development, see
-https://github.com/swaywm/sway.
+source contributors. For more information about swaylock development, see
+https://github.com/swaywm/swaylock.


### PR DESCRIPTION
I noticed the `sway-version` option while packaging `swaylock` for NixOS and found a few additional occurrences while creating this patch. I guess it makes sense to update them since `swaylock` was split out of the `sway` repository and is now an independent package.