### PR TITLE
Log error and exit if swaylock is suid with PAM backend.

### DIFF
--- a/include/swaylock.h
+++ b/include/swaylock.h
@@ -112,7 +112,7 @@ void damage_state(struct swaylock_state *state);
 void clear_password_buffer(struct swaylock_password *pw);
 void schedule_indicator_clear(struct swaylock_state *state);
 
-void initialize_pw_backend(void);
+void initialize_pw_backend(int argc, char **argv);
 void run_pw_backend_child(void);
 void clear_buffer(char *buf, size_t size);
 

--- a/main.c
+++ b/main.c
@@ -970,7 +970,7 @@ static void comm_in(int fd, short mask, void *data) {
 
 int main(int argc, char **argv) {
 	swaylock_log_init(LOG_ERROR);
-	initialize_pw_backend();
+	initialize_pw_backend(argc, argv);
 
 	enum line_mode line_mode = LM_LINE;
 	state.args = (struct swaylock_args){

--- a/pam.c
+++ b/pam.c
@@ -12,6 +12,11 @@
 static char *pw_buf = NULL;
 
 void initialize_pw_backend(void) {
+	if (getuid() != geteuid() || getgid() != getegid()) {
+		swaylock_log(LOG_ERROR,
+			"swaylock has suid but doesn't require it with PAM backend");
+		exit(EXIT_FAILURE);
+	}
 	if (!spawn_comm_child()) {
 		exit(EXIT_FAILURE);
 	}

--- a/pam.c
+++ b/pam.c
@@ -11,10 +11,11 @@
 
 static char *pw_buf = NULL;
 
-void initialize_pw_backend(void) {
+void initialize_pw_backend(int argc, char **argv) {
 	if (getuid() != geteuid() || getgid() != getegid()) {
 		swaylock_log(LOG_ERROR,
-			"swaylock has suid but doesn't require it with PAM backend");
+			"swaylock is setuid, but was compiled with the PAM"
+			" backend. Run 'chmod a-s %s' to fix. Aborting.", argv[0]);
 		exit(EXIT_FAILURE);
 	}
 	if (!spawn_comm_child()) {


### PR DESCRIPTION
Closes #15.

I looked at how this was done on Sway. I think I know how it works - by comparing the user's ID and the effective user's ID (which might be root) we can tell if the executable has suid set.