### PR TITLE
Allow downstream to disable manpages even if scdoc is found

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -44,7 +44,7 @@ crypt          = cc.find_library('crypt', required: not libpam.found())
 math           = cc.find_library('m')
 
 git = find_program('git', required: false)
-scdoc = find_program('scdoc', required: false)
+scdoc = find_program('scdoc', required: get_option('man-pages'))
 wayland_scanner = find_program('wayland-scanner')
 
 version = get_option('swaylock-version')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,6 +1,7 @@
 option('swaylock-version', type : 'string', description: 'The version string reported in `swaylock --version`')
 option('pam', type: 'feature', value: 'auto', description: 'Use PAM instead of shadow')
 option('gdk-pixbuf', type: 'feature', value: 'auto', description: 'Enable support for more image formats')
+option('man-pages', type: 'feature', value: 'auto', description: 'Generate and install man pages')
 option('zsh-completions', type: 'boolean', value: true, description: 'Install zsh shell completions')
 option('bash-completions', type: 'boolean', value: true, description: 'Install bash shell completions')
 option('fish-completions', type: 'boolean', value: true, description: 'Install fish shell completions')


### PR DESCRIPTION
See https://github.com/swaywm/sway/pull/3452. `gdk-pixbuf` is already an option since https://github.com/swaywm/swaylock/pull/22.
