### PR TITLE
Allow setting both background image and colour

### DIFF
--- a/main.c
+++ b/main.c
@@ -658,7 +658,6 @@ static int parse_options(int argc, char **argv, struct swaylock_state *state,
 		case 'c':
 			if (state) {
 				state->args.colors.background = parse_color(optarg);
-				state->args.mode = BACKGROUND_MODE_SOLID_COLOR;
 			}
 			break;
 		case 'd':

--- a/render.c
+++ b/render.c
@@ -59,10 +59,10 @@ void render_frame(struct swaylock_surface *surface) {
 
 	cairo_save(cairo);
 	cairo_set_operator(cairo, CAIRO_OPERATOR_SOURCE);
-	if (state->args.mode == BACKGROUND_MODE_SOLID_COLOR || !surface->image) {
-		cairo_set_source_u32(cairo, state->args.colors.background);
-		cairo_paint(cairo);
-	} else {
+	cairo_set_source_u32(cairo, state->args.colors.background);
+	cairo_paint(cairo);
+	if (surface->image && state->args.mode != BACKGROUND_MODE_SOLID_COLOR) {
+		cairo_set_operator(cairo, CAIRO_OPERATOR_OVER);
 		render_background_image(cairo, surface->image,
 				state->args.mode, buffer_width, buffer_height);
 	}

--- a/swaylock.1.scd
+++ b/swaylock.1.scd
@@ -55,15 +55,16 @@ Locks your Wayland session.
 	Show the current Caps Lock state also on the indicator.
 
 *-s, --scaling*
-	Scaling mode for images: _stretch_, _fill_, _fit_, _center_, or _tile_.
+	Scaling mode for images: _stretch_, _fill_, _fit_, _center_, or _tile_. Use
+	the additional mode _solid\_color_ to display only the background color, even
+	if a background image is specified.
 
 *-t, --tiling*
 	Same as --scaling=tile.
 
 *-c, --color* <rrggbb[aa]>
 	Turn the screen into the given color. If -i is used, this sets the
-	background of the image to the given color. Defaults to white (FFFFFF), or
-	transparent (00000000) if an image is in use.
+	background of the image to the given color. Defaults to white (FFFFFF).
 
 *--bs-hl-color* <rrggbb[aa]>
 	Sets the color of backspace highlight segments.


### PR DESCRIPTION
This fixes #29 (for my use case) by unconditionally drawing the background colour and afterwards the background image, if specified.

Previously, the lockscreen would display the given background image only if it was specified and the mode was not `BACKGROUND_MODE_SOLID_COLOR`. This mode was set by the `-c` option, hence overriding a given image.

However, this changes the default background colour for the `-i` option from transparent to white, so I'm not sure if this is the proper way to fix this.