### PR TITLE
Sleep on incorrect password with shadow backend.

### DIFF
--- a/shadow.c
+++ b/shadow.c
@@ -92,8 +92,12 @@ void run_pw_backend_child(void) {
 			exit(EXIT_FAILURE);
 		}
 
+		// We don't want to keep it in memory longer than necessary,
+		// so clear *before* sleeping.
 		clear_buffer(buf, size);
 		free(buf);
+
+		sleep(2);
 	}
 
 	clear_buffer(encpw, strlen(encpw));


### PR DESCRIPTION
Closes #18.

I was thinking of perhaps doubling the timeout each time an incorrect password was entered, but decided to go with a constant 2 second timeout for the sake of simplicity.

Open to other suggestions.