### PR TITLE
Add option show-failed-attempts

### DIFF
--- a/include/swaylock.h
+++ b/include/swaylock.h
@@ -50,6 +50,7 @@ struct swaylock_args {
 	bool show_indicator;
 	bool show_caps_lock_text;
 	bool show_caps_lock_indicator;
+	bool show_failed_attempts;
 	bool daemonize;
 };
 
@@ -73,6 +74,7 @@ struct swaylock_state {
 	struct swaylock_password password;
 	struct swaylock_xkb xkb;
 	enum auth_state auth_state;
+	int failed_attempts;
 	bool run_display;
 	struct zxdg_output_manager_v1 *zxdg_output_manager;
 };

--- a/render.c
+++ b/render.c
@@ -86,6 +86,7 @@ void render_frame(struct swaylock_surface *surface) {
 
 		// Draw a message
 		char *text = NULL;
+		char attempts[4]; // like i3lock: count no more than 999
 		set_color_for_state(cairo, state, &state->args.colors.text);
 		cairo_select_font_face(cairo, state->args.font,
 				CAIRO_FONT_SLANT_NORMAL, CAIRO_FONT_WEIGHT_NORMAL);
@@ -103,8 +104,17 @@ void render_frame(struct swaylock_surface *surface) {
 		case AUTH_STATE_INPUT:
 		case AUTH_STATE_INPUT_NOP:
 		case AUTH_STATE_BACKSPACE:
+			// Caps Lock has higher priority
 			if (state->xkb.caps_lock && state->args.show_caps_lock_text) {
 				text = "Caps Lock";
+			} else if (state->args.show_failed_attempts &&
+					state->failed_attempts > 0) {
+				if (state->failed_attempts > 999) {
+					text = "999+";
+				} else {
+					snprintf(attempts, sizeof(attempts), "%d", state->failed_attempts);
+					text = attempts;
+				}
 			}
 			break;
 		default:

--- a/swaylock.1.scd
+++ b/swaylock.1.scd
@@ -54,6 +54,9 @@ Locks your Wayland session.
 *-l, --indicator-caps-lock*
 	Show the current Caps Lock state also on the indicator.
 
+*-F, --show-failed-attempts*
+	Show the number of failed authentication attempts on the indicator.
+
 *-s, --scaling*
 	Scaling mode for images: _stretch_, _fill_, _fit_, _center_, or _tile_. Use
 	the additional mode _solid\_color_ to display only the background color, even


### PR DESCRIPTION
Displays the current number of failed attempts in the center of the indicator if `show-failed-attempts` is given, just like i3lock does.

Closes #4.