### PR TITLE
Support fork-free locking notification mechanism

### DIFF
--- a/include/swaylock.h
+++ b/include/swaylock.h
@@ -57,6 +57,9 @@ struct swaylock_args {
 	bool hide_keyboard_layout;
 	bool show_failed_attempts;
 	bool daemonize;
+#ifdef ENABLE_READYFD
+	int readyfd;
+#endif /* ENABLE_READYFD */
 };
 
 struct swaylock_password {

--- a/meson.build
+++ b/meson.build
@@ -35,6 +35,10 @@ if is_freebsd
 	add_project_arguments('-D_C11_SOURCE', language: 'c')
 endif
 
+if get_option('readyfd')
+	add_project_arguments('-DENABLE_READYFD', language: 'c')
+endif
+
 wayland_client = dependency('wayland-client')
 wayland_protos = dependency('wayland-protocols', version: '>=1.14')
 xkbcommon      = dependency('xkbcommon')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -4,3 +4,4 @@ option('man-pages', type: 'feature', value: 'auto', description: 'Generate and i
 option('zsh-completions', type: 'boolean', value: true, description: 'Install zsh shell completions')
 option('bash-completions', type: 'boolean', value: true, description: 'Install bash shell completions')
 option('fish-completions', type: 'boolean', value: true, description: 'Install fish shell completions')
+option('readyfd', type: 'boolean', value: false, description: 'Enable support for READY_FD protocol')


### PR DESCRIPTION
This allows for service/task managers to be notified when the lock screen has been displayed. It is particularly useful when locking the screen before closing the lid. The daemonization option can also be used, but then you either lose supervision of the swaylock process or resort to hacks like ptrace or cgroups.

Documentation for READY_FD can be found [here](https://gitlab.com/chinstrap/ready).

It is loosely based on [s6's service readiness notification mechanism](https://skarnet.org/software/s6/notifywhenup.html), and compatible with s6.