### PR TITLE
Set version in project file

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,7 @@
 project(
 	'swaylock',
 	'c',
+	version: '1.3',
 	license: 'MIT',
 	meson_version: '>=0.48.0',
 	default_options: [
@@ -47,17 +48,12 @@ git = find_program('git', required: false)
 scdoc = find_program('scdoc', required: get_option('man-pages'))
 wayland_scanner = find_program('wayland-scanner')
 
-version = get_option('swaylock-version')
-if version != ''
-	version = '"@0@"'.format(version)
-else
-	if not git.found()
-		error('git is required to make the version string')
-	endif
-
+if git.found()
 	git_commit_hash = run_command([git.path(), 'describe', '--always', '--tags']).stdout().strip()
 	git_branch = run_command([git.path(), 'rev-parse', '--abbrev-ref', 'HEAD']).stdout().strip()
 	version = '"@0@ (" __DATE__ ", branch \'@1@\')"'.format(git_commit_hash, git_branch)
+else
+	version = '"@0@"'.format(meson.project_version())
 endif
 add_project_arguments('-DSWAYLOCK_VERSION=@0@'.format(version), language: 'c')
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,4 +1,3 @@
-option('swaylock-version', type : 'string', description: 'The version string reported in `swaylock --version`')
 option('pam', type: 'feature', value: 'auto', description: 'Use PAM instead of shadow')
 option('gdk-pixbuf', type: 'feature', value: 'auto', description: 'Enable support for more image formats')
 option('man-pages', type: 'feature', value: 'auto', description: 'Generate and install man pages')


### PR DESCRIPTION
Let's set the version in the meson file instead of declaring it outside.

In case git is installed we use the git hash as version. Instead it
isn't (like on a clean build system), let's use the version defined in
the project.

Related to https://github.com/swaywm/swaylock/issues/44