### PR TITLE
Show current xkb layout while typing

### DIFF
--- a/include/swaylock.h
+++ b/include/swaylock.h
@@ -34,6 +34,9 @@ struct swaylock_colors {
 	uint32_t caps_lock_bs_highlight;
 	uint32_t caps_lock_key_highlight;
 	uint32_t separator;
+	uint32_t layout_background;
+	uint32_t layout_border;
+	uint32_t layout_text;
 	struct swaylock_colorset inside;
 	struct swaylock_colorset line;
 	struct swaylock_colorset ring;
@@ -50,6 +53,7 @@ struct swaylock_args {
 	bool show_indicator;
 	bool show_caps_lock_text;
 	bool show_caps_lock_indicator;
+	bool show_keyboard_layout;
 	bool show_failed_attempts;
 	bool daemonize;
 };

--- a/swaylock.1.scd
+++ b/swaylock.1.scd
@@ -27,6 +27,9 @@ Locks your Wayland session.
 *-e, --ignore-empty-password*
 	When an empty password is provided by the user, do not validate it.
 
+*-F, --show-failed-attempts*
+	Show the number of failed authentication attempts on the indicator.
+
 *-f, --daemonize*
 	Detach from the controlling terminal after locking.
 
@@ -48,14 +51,15 @@ Locks your Wayland session.
 	a background color. If the path potentially contains a ':', prefix it with another
 	':' to prevent interpreting part of it as <output>.
 
+*-k, --show-keyboard-layout*
+	Force displaying the current xkb layout while typing, even if only one layout
+	is configured.
+
 *-L, --disable-caps-lock-text*
 	Disable the Caps Lock Text.
 
 *-l, --indicator-caps-lock*
 	Show the current Caps Lock state also on the indicator.
-
-*-F, --show-failed-attempts*
-	Show the number of failed authentication attempts on the indicator.
 
 *-s, --scaling*
 	Scaling mode for images: _stretch_, _fill_, _fit_, _center_, or _tile_. Use
@@ -106,6 +110,15 @@ Locks your Wayland session.
 
 *--key-hl-color* <rrggbb[aa]>
 	Sets the color of key press highlight segments.
+
+*--layout-bg-color* <rrggbb[aa]>
+	Sets the background color of the box containing the layout text.
+
+*--layout-border-color* <rrggbb[aa]>
+	Sets the color of the border of the box containing the layout text.
+
+*--layout-text-color* <rrggbb[aa]>
+	Sets the color of the layout text.
 
 *--line-color* <rrggbb[aa]>
 	Sets the color of the lines that separate the inside and outside of the


### PR DESCRIPTION
This fixes #34, i.e. displays the current keyboard layout while typing. Since the layout strings can be moderately long, they usually don't fit into the indicator without being unreadably small.

I thus chose to display the layout at the top of the screen in a box, like this:

![grim_2019-02-05-162259485332674](https://user-images.githubusercontent.com/17952483/52291389-853eb280-2972-11e9-95e0-6e68009104b4.png)

I also tried putting the text directly above the indicator, but I did not like the look of it.

So there are some questions:
 * Is the current position alright?
 * Is the background box necessary or should the user make sure the text is readable on their background?
 * If using the box, are the colours OK, should they be separately configurable? Is the green (resp. ring-coloured) border necessary?

Maybe your opinions differ on how this should look.