### PR TITLE
Fix minor typo in man page

### DIFF
--- a/swaylock.1.scd
+++ b/swaylock.1.scd
@@ -79,7 +79,7 @@ Locks your Wayland session.
 *--caps-lock-bs-hl-color* <rrggbb[aa]>
 	Sets the color of backspace highlight segments when Caps Lock is active.
 
-*--caps-lock-bs-hl-color* <rrggbb[aa]>
+*--caps-lock-key-hl-color* <rrggbb[aa]>
 	Sets the color of the key press highlight segments when Caps Lock is active.
 
 *--font* <font>


### PR DESCRIPTION
The man page has a small typo:
`--caps-lock-bs-hl-color <color>` should be `--caps-lock-key-hl-color <color>` according to `swaylock --help`