### PR TITLE
Do not exit if no outputs are present

### DIFF
--- a/main.c
+++ b/main.c
@@ -1108,12 +1108,6 @@ int main(int argc, char **argv) {
 		return 1;
 	}
 
-	if (wl_list_empty(&state.surfaces)) {
-		free(state.args.font);
-		swaylock_log(LOG_ERROR, "Exiting - no outputs to show on.");
-		return 0;
-	}
-
 	zwlr_input_inhibit_manager_v1_get_inhibitor(state.input_inhibit_manager);
 	if (wl_display_roundtrip(state.display) == -1) {
 		free(state.args.font);


### PR DESCRIPTION
swaylock should not exit if no outputs are present, as outputs may become present later.

Personally hit this by having a lid switch handler turn of eDP-1 (for convenience in a docked setup where a third screen is not wanted), while using logind + swayidle beforesleep to lock the screen when closing the lid when not connected to a dock.

This lead to no active outputs being active at the time swaylock is instantiated by suspend on lid close, leaving the laptop unlocked when the lid is again opened and its output reactivated.