### PR TITLE
Add hide keyboard layout option

### DIFF
--- a/include/swaylock.h
+++ b/include/swaylock.h
@@ -54,6 +54,7 @@ struct swaylock_args {
 	bool show_caps_lock_text;
 	bool show_caps_lock_indicator;
 	bool show_keyboard_layout;
+	bool hide_keyboard_layout;
 	bool show_failed_attempts;
 	bool daemonize;
 };

--- a/main.c
+++ b/main.c
@@ -550,6 +550,7 @@ static int parse_options(int argc, char **argv, struct swaylock_state *state,
 		{"tiling", no_argument, NULL, 't'},
 		{"no-unlock-indicator", no_argument, NULL, 'u'},
 		{"show-keyboard-layout", no_argument, NULL, 'k'},
+		{"hide-keyboard-layout", no_argument, NULL, 'K'},
 		{"show-failed-attempts", no_argument, NULL, 'F'},
 		{"version", no_argument, NULL, 'v'},
 		{"bs-hl-color", required_argument, NULL, LO_BS_HL_COLOR},
@@ -607,6 +608,8 @@ static int parse_options(int argc, char **argv, struct swaylock_state *state,
 			"Display the given image.\n"
 		"  -k, --show-keyboard-layout       "
 			"Display the current xkb layout while typing.\n"
+		"  -K, --hide-keyboard-layout       "
+			"Hide the current xkb layout while typing.\n"
 		"  -L, --disable-caps-lock-text     "
 			"Disable the Caps Lock text.\n"
 		"  -l, --indicator-caps-lock        "
@@ -700,7 +703,7 @@ static int parse_options(int argc, char **argv, struct swaylock_state *state,
 	optind = 1;
 	while (1) {
 		int opt_idx = 0;
-		c = getopt_long(argc, argv, "c:deFfhi:kLlnrs:tuvC:", long_options,
+		c = getopt_long(argc, argv, "c:deFfhi:kKLlnrs:tuvC:", long_options,
 				&opt_idx);
 		if (c == -1) {
 			break;
@@ -742,6 +745,11 @@ static int parse_options(int argc, char **argv, struct swaylock_state *state,
 		case 'k':
 			if (state) {
 				state->args.show_keyboard_layout = true;
+			}
+			break;
+		case 'K':
+			if (state) {
+				state->args.hide_keyboard_layout = true;
 			}
 			break;
 		case 'L':
@@ -1063,6 +1071,7 @@ int main(int argc, char **argv) {
 		.show_caps_lock_indicator = false,
 		.show_caps_lock_text = true,
 		.show_keyboard_layout = false,
+		.hide_keyboard_layout = false,
 		.show_failed_attempts = false
 	};
 	wl_list_init(&state.images);

--- a/render.c
+++ b/render.c
@@ -156,7 +156,8 @@ void render_frame(struct swaylock_surface *surface) {
 			}
 
 			xkb_layout_index_t num_layout = xkb_keymap_num_layouts(state->xkb.keymap);
-			if (state->args.show_keyboard_layout || num_layout > 1) {
+			if (!state->args.hide_keyboard_layout && 
+					(state->args.show_keyboard_layout || num_layout > 1)) {
 				xkb_layout_index_t curr_layout = 0;
 
 				// advance to the first active layout (if any)

--- a/swaylock.1.scd
+++ b/swaylock.1.scd
@@ -55,6 +55,10 @@ Locks your Wayland session.
 	Force displaying the current xkb layout while typing, even if only one layout
 	is configured.
 
+*-K, --hide-keyboard-layout*
+	Force hiding the current xkb layout while typing, even if more than one layout
+	is configured or the show-keyboard-layout option is set.
+
 *-L, --disable-caps-lock-text*
 	Disable the Caps Lock Text.
 


### PR DESCRIPTION
I added a `--hide-keyboard-layout` option which can also be activated with `-K`, as an inverse of the `--show-keyboard-layout` option which can be activated with `-k`. One thing I noticed when testing was that when I didn't use the hide layout option the keyboard layout text was cut off on both sides, although my code shouldn't affect  how it was rendered and I still have that issue on master without my changes. 

Fixes #60 