### PR TITLE
Submit password by pressing Ctrl+m (close #75)

### DIFF
--- a/password.c
+++ b/password.c
@@ -137,6 +137,7 @@ void swaylock_handle_key(struct swaylock_state *state,
 		schedule_indicator_clear(state);
 		schedule_password_clear(state);
 		break;
+	case XKB_KEY_m: /* fallthrough */
 	case XKB_KEY_d:
 		if (state->xkb.control) {
 			submit_password(state);


### PR DESCRIPTION
This allows one to submit the password by pressing Ctrl+m, which is the same behavior as by currently pressing Ctrl+d.