### PR TITLE
Add fixed font-size option for indicator

### DIFF
--- a/include/swaylock.h
+++ b/include/swaylock.h
@@ -47,6 +47,7 @@ struct swaylock_args {
 	struct swaylock_colors colors;
 	enum background_mode mode;
 	char *font;
+	uint32_t font_size;
 	uint32_t radius;
 	uint32_t thickness;
 	bool ignore_empty;

--- a/main.c
+++ b/main.c
@@ -504,6 +504,7 @@ static int parse_options(int argc, char **argv, struct swaylock_state *state,
 		LO_CAPS_LOCK_BS_HL_COLOR,
 		LO_CAPS_LOCK_KEY_HL_COLOR,
 		LO_FONT,
+		LO_FONT_SIZE,
 		LO_IND_RADIUS,
 		LO_IND_THICKNESS,
 		LO_INSIDE_COLOR,
@@ -557,6 +558,7 @@ static int parse_options(int argc, char **argv, struct swaylock_state *state,
 		{"caps-lock-bs-hl-color", required_argument, NULL, LO_CAPS_LOCK_BS_HL_COLOR},
 		{"caps-lock-key-hl-color", required_argument, NULL, LO_CAPS_LOCK_KEY_HL_COLOR},
 		{"font", required_argument, NULL, LO_FONT},
+		{"font-size", required_argument, NULL, LO_FONT_SIZE},
 		{"indicator-radius", required_argument, NULL, LO_IND_RADIUS},
 		{"indicator-thickness", required_argument, NULL, LO_IND_THICKNESS},
 		{"inside-color", required_argument, NULL, LO_INSIDE_COLOR},
@@ -632,6 +634,8 @@ static int parse_options(int argc, char **argv, struct swaylock_state *state,
 			"Caps Lock is active.\n"
 		"  --font <font>                    "
 			"Sets the font of the text.\n"
+		"  --font-size <size>               "
+			"Sets a fixed font size for the indicator text.\n"
 		"  --indicator-radius <radius>      "
 			"Sets the indicator radius.\n"
 		"  --indicator-thickness <thick>    "
@@ -813,6 +817,11 @@ static int parse_options(int argc, char **argv, struct swaylock_state *state,
 			if (state) {
 				free(state->args.font);
 				state->args.font = strdup(optarg);
+			}
+			break;
+		case LO_FONT_SIZE:
+			if (state) {
+				state->args.font_size = atoi(optarg);
 			}
 			break;
 		case LO_IND_RADIUS:
@@ -1064,6 +1073,7 @@ int main(int argc, char **argv) {
 	state.args = (struct swaylock_args){
 		.mode = BACKGROUND_MODE_FILL,
 		.font = strdup("sans-serif"),
+		.font_size = 0,
 		.radius = 50,
 		.thickness = 10,
 		.ignore_empty = false,

--- a/render.c
+++ b/render.c
@@ -128,7 +128,11 @@ void render_frame(struct swaylock_surface *surface) {
 		set_color_for_state(cairo, state, &state->args.colors.text);
 		cairo_select_font_face(cairo, state->args.font,
 				CAIRO_FONT_SLANT_NORMAL, CAIRO_FONT_WEIGHT_NORMAL);
-		cairo_set_font_size(cairo, arc_radius / 3.0f);
+		if (state->args.font_size > 0) {
+		  cairo_set_font_size(cairo, state->args.font_size);
+		} else {
+		  cairo_set_font_size(cairo, arc_radius / 3.0f);
+		}
 		switch (state->auth_state) {
 		case AUTH_STATE_VALIDATING:
 			text = "verifying";


### PR DESCRIPTION
This commit adds a new command line option called --font-size to specify a fixed font size in the indicator. The default value for font-size is 0, which means that the text will autoscale. Any other positive value will result in a fixed text size.