### PR TITLE
Resizing buffer based on the size of its content

### DIFF
--- a/include/swaylock.h
+++ b/include/swaylock.h
@@ -101,6 +101,7 @@ struct swaylock_surface {
 	struct pool_buffer *current_buffer;
 	bool frame_pending, dirty;
 	uint32_t width, height;
+	uint32_t indicator_width, indicator_height;
 	int32_t scale;
 	enum wl_output_subpixel subpixel;
 	char *output_name;

--- a/main.c
+++ b/main.c
@@ -168,6 +168,8 @@ static void layer_surface_configure(void *data,
 	struct swaylock_surface *surface = data;
 	surface->width = width;
 	surface->height = height;
+	surface->indicator_width = 1;
+	surface->indicator_height = 1;
 	zwlr_layer_surface_v1_ack_configure(layer_surface, serial);
 	render_frame_background(surface);
 	render_frame(surface);

--- a/render.c
+++ b/render.c
@@ -129,9 +129,9 @@ void render_frame(struct swaylock_surface *surface) {
 		cairo_select_font_face(cairo, state->args.font,
 				CAIRO_FONT_SLANT_NORMAL, CAIRO_FONT_WEIGHT_NORMAL);
 		if (state->args.font_size > 0) {
-		  cairo_set_font_size(cairo, state->args.font_size);
+			cairo_set_font_size(cairo, state->args.font_size);
 		} else {
-		  cairo_set_font_size(cairo, arc_radius / 3.0f);
+			cairo_set_font_size(cairo, arc_radius / 3.0f);
 		}
 		switch (state->auth_state) {
 		case AUTH_STATE_VALIDATING:
@@ -160,7 +160,7 @@ void render_frame(struct swaylock_surface *surface) {
 			}
 
 			xkb_layout_index_t num_layout = xkb_keymap_num_layouts(state->xkb.keymap);
-			if (!state->args.hide_keyboard_layout && 
+			if (!state->args.hide_keyboard_layout &&
 					(state->args.show_keyboard_layout || num_layout > 1)) {
 				xkb_layout_index_t curr_layout = 0;
 
@@ -265,7 +265,6 @@ void render_frame(struct swaylock_surface *surface) {
 			// border
 			cairo_set_source_u32(cairo, state->args.colors.layout_border);
 			cairo_stroke(cairo);
-			cairo_new_sub_path(cairo);
 
 			// take font extents and padding into account
 			cairo_move_to(cairo,

--- a/seat.c
+++ b/seat.c
@@ -62,6 +62,11 @@ static void keyboard_modifiers(void *data, struct wl_keyboard *wl_keyboard,
 		uint32_t serial, uint32_t mods_depressed, uint32_t mods_latched,
 		uint32_t mods_locked, uint32_t group) {
 	struct swaylock_state *state = data;
+	int layout_same = xkb_state_layout_index_is_active(state->xkb.state,
+		group, XKB_STATE_LAYOUT_EFFECTIVE);
+	if (!layout_same) {
+		damage_state(state);
+	}
 	xkb_state_update_mask(state->xkb.state,
 		mods_depressed, mods_latched, mods_locked, 0, 0, group);
 	int caps_lock = xkb_state_mod_name_is_active(state->xkb.state,

--- a/seat.c
+++ b/seat.c
@@ -22,7 +22,8 @@ static void keyboard_keymap(void *data, struct wl_keyboard *wl_keyboard,
 		exit(1);
 	}
 	struct xkb_keymap *keymap = xkb_keymap_new_from_string(
-			state->xkb.context, map_shm, XKB_KEYMAP_FORMAT_TEXT_V1, 0);
+			state->xkb.context, map_shm, XKB_KEYMAP_FORMAT_TEXT_V1,
+			XKB_KEYMAP_COMPILE_NO_FLAGS);
 	munmap(map_shm, size);
 	close(fd);
 	assert(keymap);
@@ -72,7 +73,6 @@ static void keyboard_modifiers(void *data, struct wl_keyboard *wl_keyboard,
 	state->xkb.control = xkb_state_mod_name_is_active(state->xkb.state,
 		XKB_MOD_NAME_CTRL,
 		XKB_STATE_MODS_DEPRESSED | XKB_STATE_MODS_LATCHED);
-
 }
 
 static void keyboard_repeat_info(void *data, struct wl_keyboard *wl_keyboard,


### PR DESCRIPTION
Since the buffer is based on the arc radius and thickness, it is often small enough so that keymap names like "French (Canada)" or "English (the divide/multiply keys toggle the layout)" are truncated.

This is more pronounced when a bigger font size is used.

The simplest solution is pretty much to use a fullscreen buffer.

Related to #88