### PR TITLE
fix indicator position

### DIFF
--- a/render.c
+++ b/render.c
@@ -80,9 +80,10 @@ void render_frame(struct swaylock_surface *surface) {
 	int new_width = buffer_diameter;
 	int new_height = buffer_diameter;
 
-	int subsurf_xpos = surface->width / 2 - buffer_width / 2;
+	int subsurf_xpos = surface->width / 2 -
+		(state->args.radius + state->args.thickness) + 2 / surface->scale;
 	int subsurf_ypos = surface->height / 2 -
-		(state->args.radius + state->args.thickness);
+		(state->args.radius + state->args.thickness) + 2 / surface->scale;
 	wl_subsurface_set_position(surface->subsurface, subsurf_xpos, subsurf_ypos);
 
 	surface->current_buffer = get_next_buffer(state->shm,


### PR DESCRIPTION
On my laptop's scaled 4k display, the indicator's X position was off:
![shot-2x](https://user-images.githubusercontent.com/3728194/60337658-f7587800-99a3-11e9-9e47-9072b0f7eb89.png)

It was also slightly off at 1x:
![shot-1x](https://user-images.githubusercontent.com/3728194/60337749-35559c00-99a4-11e9-96dc-4eab39c8bb0a.png)

I have to admit I don't 100% understand how the original code works, so this fix might be wrong, but it seems to work on my hardware at least. It changes the calculation of the X position to be just like how the Y position is calculated.

It also adds a 2 real pixel offset, to account for what I assume is an offset caused by integer division. A better solution than fudging the numbers like that might be to do all calculations using floats, and then round (not floor) when converting to hard pixel values, but I didn't want to make such a big change.