### PR TITLE
Properly fix indicator position

### DIFF
--- a/render.c
+++ b/render.c
@@ -81,9 +81,9 @@ void render_frame(struct swaylock_surface *surface) {
 	int new_height = buffer_diameter;
 
 	int subsurf_xpos = surface->width / 2 -
-		(state->args.radius + state->args.thickness) + 2 / surface->scale;
+		buffer_width / (2 * surface->scale) + 2 / surface->scale;
 	int subsurf_ypos = surface->height / 2 -
-		(state->args.radius + state->args.thickness) + 2 / surface->scale;
+		(state->args.radius + state->args.thickness);
 	wl_subsurface_set_position(surface->subsurface, subsurf_xpos, subsurf_ypos);
 
 	surface->current_buffer = get_next_buffer(state->shm,


### PR DESCRIPTION
I found out that my [previous attempt](https://github.com/swaywm/swaylock/pull/92) at fixing the indicator position on scaled displays didn't quite work; it broke when the width of the subsurface was changed to be wider than the indicator due to the keyboard layout text.

Playing around with it to try to fix it in [my own swaylock-fork](https://github.com/mortie/swaylock-effects), I found that the main error with the old way was that `buffer_width` isn't scaled, so half the width of the subsurface in wayland units is `buffer_width / (2 * scale)`, not `buffer_width / 2`.