### PR TITLE
Adds option to show indicator even if idle

### DIFF
--- a/completions/fish/swaylock.fish
+++ b/completions/fish/swaylock.fish
@@ -15,6 +15,7 @@ complete -c swaylock -s t -l tiling --description "Same as --scaling=tile."
 complete -c swaylock -s c -l color --description "Turn the screen into the given color. If -i is used, this sets the background of the image into the given color. Defaults to white (ffffff), or transparent (00000000) if an image is in use."
 complete -c swaylock -l bs-hl-color --description 'Sets the color of backspace highlight segments.'
 complete -c swaylock -l font --description 'Sets the font of the text inside the indicator.'
+complete -c swaylock -l indicator-idle-visible --description 'Sets the indicator to show even if idle.'
 complete -c swaylock -l indicator-radius --description 'Sets the radius of the indicator to radius pixels. Default: 50'
 complete -c swaylock -l indicator-thickness --description 'Sets the thickness of the indicator to thickness pixels. Default: 10'
 complete -c swaylock -l inside-color --description 'Sets the color of the inside of the indicator when typing or idle.'

--- a/completions/zsh/_swaylock
+++ b/completions/zsh/_swaylock
@@ -16,6 +16,7 @@ _arguments -s \
 	'(-v --version)'{-v,--version}'[Show the version number and quit]' \
 	'(--bs-hl-color)'--bs-hl-color'[Sets the color of backspace highlights segments]:color:' \
 	'(--font)'--font'[Sets the font of the text]:font:' \
+	'(--indicator-idle-visible)'--indicator-idle-visible'[Sets the indicator to show even if idle]' \
 	'(--indicator-radius)'--indicator-radius'[Sets the indicator radius]:radius:' \
 	'(--indicator-thickness)'--indicator-thickness'[Sets the indicator thickness]:thickness:' \
 	'(--inside-color)'--inside-color'[Sets the color of the inside of the indicator]:color:' \

--- a/include/swaylock.h
+++ b/include/swaylock.h
@@ -58,6 +58,7 @@ struct swaylock_args {
 	bool hide_keyboard_layout;
 	bool show_failed_attempts;
 	bool daemonize;
+	bool indicator_idle_visible;
 };
 
 struct swaylock_password {

--- a/main.c
+++ b/main.c
@@ -507,6 +507,7 @@ static int parse_options(int argc, char **argv, struct swaylock_state *state,
 		LO_CAPS_LOCK_KEY_HL_COLOR,
 		LO_FONT,
 		LO_FONT_SIZE,
+		LO_IND_IDLE_VISIBLE,
 		LO_IND_RADIUS,
 		LO_IND_THICKNESS,
 		LO_INSIDE_COLOR,
@@ -561,6 +562,7 @@ static int parse_options(int argc, char **argv, struct swaylock_state *state,
 		{"caps-lock-key-hl-color", required_argument, NULL, LO_CAPS_LOCK_KEY_HL_COLOR},
 		{"font", required_argument, NULL, LO_FONT},
 		{"font-size", required_argument, NULL, LO_FONT_SIZE},
+		{"indicator-idle-visible", no_argument, NULL, LO_IND_IDLE_VISIBLE},
 		{"indicator-radius", required_argument, NULL, LO_IND_RADIUS},
 		{"indicator-thickness", required_argument, NULL, LO_IND_THICKNESS},
 		{"inside-color", required_argument, NULL, LO_INSIDE_COLOR},
@@ -638,6 +640,8 @@ static int parse_options(int argc, char **argv, struct swaylock_state *state,
 			"Sets the font of the text.\n"
 		"  --font-size <size>               "
 			"Sets a fixed font size for the indicator text.\n"
+		"  --indicator-idle-visible         "
+			"Sets the indicator to show even if idle.\n"
 		"  --indicator-radius <radius>      "
 			"Sets the indicator radius.\n"
 		"  --indicator-thickness <thick>    "
@@ -824,6 +828,11 @@ static int parse_options(int argc, char **argv, struct swaylock_state *state,
 		case LO_FONT_SIZE:
 			if (state) {
 				state->args.font_size = atoi(optarg);
+			}
+			break;
+		case LO_IND_IDLE_VISIBLE:
+			if (state) {
+				state->args.indicator_idle_visible = true;
 			}
 			break;
 		case LO_IND_RADIUS:
@@ -1085,7 +1094,8 @@ int main(int argc, char **argv) {
 		.show_caps_lock_text = true,
 		.show_keyboard_layout = false,
 		.hide_keyboard_layout = false,
-		.show_failed_attempts = false
+		.show_failed_attempts = false,
+		.indicator_idle_visible = false
 	};
 	wl_list_init(&state.images);
 	set_default_colors(&state.args.colors);

--- a/render.c
+++ b/render.c
@@ -116,7 +116,8 @@ void render_frame(struct swaylock_surface *surface) {
 	float type_indicator_border_thickness =
 		TYPE_INDICATOR_BORDER_THICKNESS * surface->scale;
 
-	if (state->args.show_indicator && state->auth_state != AUTH_STATE_IDLE) {
+	if (state->args.show_indicator && (state->auth_state != AUTH_STATE_IDLE ||
+			state->args.indicator_idle_visible)) {
 		// Draw circle
 		cairo_set_line_width(cairo, arc_thickness);
 		cairo_arc(cairo, buffer_width / 2, buffer_diameter / 2, arc_radius,

--- a/swaylock.1.scd
+++ b/swaylock.1.scd
@@ -89,6 +89,9 @@ Locks your Wayland session.
 *--font* <font>
 	Sets the font of the text inside the indicator.
 
+*--indicator-idle-visible*
+	Sets the indicator to show even if idle.
+
 *--indicator-radius* <radius>
 	Sets the radius of the indicator to _radius_ pixels. The default value is
 	50.


### PR DESCRIPTION
I've found multiple times I've hit a random key to make the indicator visible (thinking I can't type my password till I see it).
  
