### PR TITLE
Set version to 1.6

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
 	'swaylock',
 	'c',
-	version: '1.4',
+	version: '1.6',
 	license: 'MIT',
 	meson_version: '>=0.48.0',
 	default_options: [


### PR DESCRIPTION
It seems this gets forgotten before doing a release.
Like last time: https://github.com/swaywm/swaylock/pull/84

So this time I will try differently and set it to the (probably)
next version number :-)