### PR TITLE
Added description of --indicator-x/y-position to man and completions

### DIFF
--- a/completions/bash/swaylock
+++ b/completions/bash/swaylock
@@ -45,6 +45,8 @@ _swaylock()
     --indicator-idle-visible
     --indicator-radius
     --indicator-thickness
+    --indicator-x-position
+    --indicator-y-position
     --inside-caps-lock-color
     --inside-clear-color
     --inside-color

--- a/completions/fish/swaylock.fish
+++ b/completions/fish/swaylock.fish
@@ -18,6 +18,8 @@ complete -c swaylock -l indicator-caps-lock    -s l --description "Show the curr
 complete -c swaylock -l indicator-idle-visible      --description "Sets the indicator to show even if idle."
 complete -c swaylock -l indicator-radius            --description "Sets the indicator radius."
 complete -c swaylock -l indicator-thickness         --description "Sets the indicator thickness."
+complete -c swaylock -l indicator-x-position        --description "Sets the horizontal position of the indicator."
+complete -c swaylock -l indicator-y-position        --description "Sets the vertical position of the indicator."
 complete -c swaylock -l inside-caps-lock-color      --description "Sets the color of the inside of the indicator when Caps Lock is active."
 complete -c swaylock -l inside-clear-color          --description "Sets the color of the inside of the indicator when cleared."
 complete -c swaylock -l inside-color                --description "Sets the color of the inside of the indicator."

--- a/completions/zsh/_swaylock
+++ b/completions/zsh/_swaylock
@@ -22,6 +22,8 @@ _arguments -s \
 	'(--indicator-idle-visible)'--indicator-idle-visible'[Sets the indicator to show even if idle]' \
 	'(--indicator-radius)'--indicator-radius'[Sets the indicator radius]:radius:' \
 	'(--indicator-thickness)'--indicator-thickness'[Sets the indicator thickness]:thickness:' \
+	'(--indicator-x-position)'--indicator-x-position'[Sets the horizontal position of the indicator]' \
+	'(--indicator-y-position)'--indicator-y-position'[Sets the vertical position of the indicator]' \
 	'(--inside-caps-lock-color)'--inside-caps-lock-color'[Sets the color of the inside of the indicator when Caps Lock is active]:color:' \
 	'(--inside-clear-color)'--inside-clear-color'[Sets the color of the inside of the indicator when cleared]:color:' \
 	'(--inside-color)'--inside-color'[Sets the color of the inside of the indicator]:color:' \

--- a/swaylock.1.scd
+++ b/swaylock.1.scd
@@ -101,6 +101,12 @@ Locks your Wayland session.
 *--indicator-thickness* <thickness>
 	Sets the indicator thickness. The default value is 10.
 
+*--indicator-x-position* <x>
+	Sets the horizontal position of the indicator.
+
+*--indicator-y-position* <y>
+	Sets the vertical position of the indicator.
+
 *--inside-color* <rrggbb[aa]>
 	Sets the color of the inside of the indicator.
 


### PR DESCRIPTION
Current version of swaylock supports --indicator-x-position and --indicator-y-position, but description is missing in man pages.