### PR TITLE
Use xkb_keymap_new_from_buffer instead of xkb_keymap_new_from_string

### DIFF
--- a/seat.c
+++ b/seat.c
@@ -15,16 +15,16 @@ static void keyboard_keymap(void *data, struct wl_keyboard *wl_keyboard,
 		swaylock_log(LOG_ERROR, "Unknown keymap format %d, aborting", format);
 		exit(1);
 	}
-	char *map_shm = mmap(NULL, size, PROT_READ, MAP_SHARED, fd, 0);
+	char *map_shm = mmap(NULL, size - 1, PROT_READ, MAP_PRIVATE, fd, 0);
 	if (map_shm == MAP_FAILED) {
 		close(fd);
 		swaylock_log(LOG_ERROR, "Unable to initialize keymap shm, aborting");
 		exit(1);
 	}
-	struct xkb_keymap *keymap = xkb_keymap_new_from_string(
-			state->xkb.context, map_shm, XKB_KEYMAP_FORMAT_TEXT_V1,
+	struct xkb_keymap *keymap = xkb_keymap_new_from_buffer(
+			state->xkb.context, map_shm, size - 1, XKB_KEYMAP_FORMAT_TEXT_V1,
 			XKB_KEYMAP_COMPILE_NO_FLAGS);
-	munmap(map_shm, size);
+	munmap(map_shm, size - 1);
 	close(fd);
 	assert(keymap);
 	struct xkb_state *xkb_state = xkb_state_new(keymap);


### PR DESCRIPTION
xkb_keymap_new_from_string just calls xkb_keymap_new_from_buffer with size as `strlen(string)`.

https://github.com/xkbcommon/libxkbcommon/blob/0f1cae0cc482575c71d29d6241115886ebf25dec/src/keymap.c#L164

According to the [spec](https://gitlab.freedesktop.org/wayland/wayland/-/blob/master/protocol/wayland.xml#L2182), MAP_PRIVATE should be used.