### PR TITLE
Implement key repeat

### DIFF
--- a/include/seat.h
+++ b/include/seat.h
@@ -1,6 +1,11 @@
 #ifndef _SWAYLOCK_SEAT_H
 #define _SWAYLOCK_SEAT_H
 #include <xkbcommon/xkbcommon.h>
+#include <stdint.h>
+#include <stdbool.h>
+
+struct loop;
+struct loop_timer;
 
 struct swaylock_xkb {
 	bool caps_lock;
@@ -14,6 +19,11 @@ struct swaylock_seat {
 	struct swaylock_state *state;
 	struct wl_pointer *pointer;
 	struct wl_keyboard *keyboard;
+	int32_t repeat_period;
+	int32_t repeat_delay;
+	uint32_t repeat_sym;
+	uint32_t repeat_codepoint;
+	struct loop_timer *repeat_timer;
 };
 
 extern const struct wl_seat_listener seat_listener;

--- a/include/seat.h
+++ b/include/seat.h
@@ -19,8 +19,8 @@ struct swaylock_seat {
 	struct swaylock_state *state;
 	struct wl_pointer *pointer;
 	struct wl_keyboard *keyboard;
-	int32_t repeat_period;
-	int32_t repeat_delay;
+	int32_t repeat_period_ms;
+	int32_t repeat_delay_ms;
 	uint32_t repeat_sym;
 	uint32_t repeat_codepoint;
 	struct loop_timer *repeat_timer;

--- a/loop.c
+++ b/loop.c
@@ -108,6 +108,7 @@ void loop_poll(struct loop *loop) {
 			if (timer->removed) {
 				wl_list_remove(&timer->link);
 				free(timer);
+				continue;
 			}
 
 			bool expired = timer->expiry.tv_sec < now.tv_sec ||

--- a/main.c
+++ b/main.c
@@ -314,7 +314,7 @@ static void handle_global(void *data, struct wl_registry *registry,
 				&wl_shm_interface, 1);
 	} else if (strcmp(interface, wl_seat_interface.name) == 0) {
 		struct wl_seat *seat = wl_registry_bind(
-				registry, name, &wl_seat_interface, 3);
+				registry, name, &wl_seat_interface, 4);
 		struct swaylock_seat *swaylock_seat =
 			calloc(1, sizeof(struct swaylock_seat));
 		swaylock_seat->state = state;

--- a/seat.c
+++ b/seat.c
@@ -6,10 +6,12 @@
 #include "log.h"
 #include "swaylock.h"
 #include "seat.h"
+#include "loop.h"
 
 static void keyboard_keymap(void *data, struct wl_keyboard *wl_keyboard,
 		uint32_t format, int32_t fd, uint32_t size) {
-	struct swaylock_state *state = data;
+	struct swaylock_seat *seat = data;
+	struct swaylock_state *state = seat->state;
 	if (format != WL_KEYBOARD_KEYMAP_FORMAT_XKB_V1) {
 		close(fd);
 		swaylock_log(LOG_ERROR, "Unknown keymap format %d, aborting", format);
@@ -45,9 +47,18 @@ static void keyboard_leave(void *data, struct wl_keyboard *wl_keyboard,
 	// Who cares
 }
 
+static void keyboard_repeat(void *data) {
+	struct swaylock_seat *seat = data;
+	struct swaylock_state *state = seat->state;
+	seat->repeat_timer = loop_add_timer(
+		state->eventloop, seat->repeat_period, keyboard_repeat, seat);
+	swaylock_handle_key(state, seat->repeat_sym, seat->repeat_codepoint);
+}
+
 static void keyboard_key(void *data, struct wl_keyboard *wl_keyboard,
 		uint32_t serial, uint32_t time, uint32_t key, uint32_t _key_state) {
-	struct swaylock_state *state = data;
+	struct swaylock_seat *seat = data;
+	struct swaylock_state *state = seat->state;
 	enum wl_keyboard_key_state key_state = _key_state;
 	xkb_keysym_t sym = xkb_state_key_get_one_sym(state->xkb.state, key + 8);
 	uint32_t keycode = key_state == WL_KEYBOARD_KEY_STATE_PRESSED ?
@@ -56,12 +67,25 @@ static void keyboard_key(void *data, struct wl_keyboard *wl_keyboard,
 	if (key_state == WL_KEYBOARD_KEY_STATE_PRESSED) {
 		swaylock_handle_key(state, sym, codepoint);
 	}
+
+	if (seat->repeat_timer) {
+		loop_remove_timer(seat->state->eventloop, seat->repeat_timer);
+		seat->repeat_timer = NULL;
+	}
+
+	if (key_state == WL_KEYBOARD_KEY_STATE_PRESSED && seat->repeat_period >= 0) {
+		seat->repeat_sym = sym;
+		seat->repeat_codepoint = codepoint;
+		seat->repeat_timer = loop_add_timer(
+			seat->state->eventloop, seat->repeat_delay, keyboard_repeat, seat);
+	}
 }
 
 static void keyboard_modifiers(void *data, struct wl_keyboard *wl_keyboard,
 		uint32_t serial, uint32_t mods_depressed, uint32_t mods_latched,
 		uint32_t mods_locked, uint32_t group) {
-	struct swaylock_state *state = data;
+	struct swaylock_seat *seat = data;
+	struct swaylock_state *state = seat->state;
 	int layout_same = xkb_state_layout_index_is_active(state->xkb.state,
 		group, XKB_STATE_LAYOUT_EFFECTIVE);
 	if (!layout_same) {
@@ -82,7 +106,14 @@ static void keyboard_modifiers(void *data, struct wl_keyboard *wl_keyboard,
 
 static void keyboard_repeat_info(void *data, struct wl_keyboard *wl_keyboard,
 		int32_t rate, int32_t delay) {
-	// TODO
+	struct swaylock_seat *seat = data;
+	if (rate <= 0) {
+		seat->repeat_period = -1;
+	} else {
+		// Keys per second -> milliseconds between keys
+		seat->repeat_period = 1000 / rate;
+	}
+	seat->repeat_delay = delay;
 }
 
 static const struct wl_keyboard_listener keyboard_listener = {
@@ -168,7 +199,7 @@ static void seat_handle_capabilities(void *data, struct wl_seat *wl_seat,
 	}
 	if ((caps & WL_SEAT_CAPABILITY_KEYBOARD)) {
 		seat->keyboard = wl_seat_get_keyboard(wl_seat);
-		wl_keyboard_add_listener(seat->keyboard, &keyboard_listener, seat->state);
+		wl_keyboard_add_listener(seat->keyboard, &keyboard_listener, seat);
 	}
 }
 

--- a/seat.c
+++ b/seat.c
@@ -51,7 +51,7 @@ static void keyboard_repeat(void *data) {
 	struct swaylock_seat *seat = data;
 	struct swaylock_state *state = seat->state;
 	seat->repeat_timer = loop_add_timer(
-		state->eventloop, seat->repeat_period, keyboard_repeat, seat);
+		state->eventloop, seat->repeat_period_ms, keyboard_repeat, seat);
 	swaylock_handle_key(state, seat->repeat_sym, seat->repeat_codepoint);
 }
 
@@ -73,11 +73,11 @@ static void keyboard_key(void *data, struct wl_keyboard *wl_keyboard,
 		seat->repeat_timer = NULL;
 	}
 
-	if (key_state == WL_KEYBOARD_KEY_STATE_PRESSED && seat->repeat_period >= 0) {
+	if (key_state == WL_KEYBOARD_KEY_STATE_PRESSED && seat->repeat_period_ms > 0) {
 		seat->repeat_sym = sym;
 		seat->repeat_codepoint = codepoint;
 		seat->repeat_timer = loop_add_timer(
-			seat->state->eventloop, seat->repeat_delay, keyboard_repeat, seat);
+			seat->state->eventloop, seat->repeat_delay_ms, keyboard_repeat, seat);
 	}
 }
 
@@ -108,12 +108,12 @@ static void keyboard_repeat_info(void *data, struct wl_keyboard *wl_keyboard,
 		int32_t rate, int32_t delay) {
 	struct swaylock_seat *seat = data;
 	if (rate <= 0) {
-		seat->repeat_period = -1;
+		seat->repeat_period_ms = -1;
 	} else {
 		// Keys per second -> milliseconds between keys
-		seat->repeat_period = 1000 / rate;
+		seat->repeat_period_ms = 1000 / rate;
 	}
-	seat->repeat_delay = delay;
+	seat->repeat_delay_ms = delay;
 }
 
 static const struct wl_keyboard_listener keyboard_listener = {


### PR DESCRIPTION
This change makes Swaylock respect your key repeat rate. Even though you could argue key repeat rate isn't super important in a screen locker, I think it's important that Swaylock acts how users expect software which accepts keyboard input to work.

As part of implementing key repeat rates, this patch:
* Fixes the event loop system such that a timer can be removed from another timer's callback. This is because `swaylock_handle_key` sometimes removes timers, and `swaylock_handle_key` is now called from a timer callback. I don't know if the way I did it is the cleanest possible way, but its the best way I could think of. Calling `loop_remove_fd` from within an fd callback will still crash; I decided to not to fix that without knowing if it'll ever be a problem.
* Makes Swaylock depend on the seat interface version 4 (for the repeat_info callback).
* Changes the pointer given to keyboard callbacks to be a pointer to a `swaylock_seat` instead of a pointer to a `swaylock_state`.