### PR TITLE
Refresh pam credentials after successful authentication

### DIFF
--- a/pam.c
+++ b/pam.c
@@ -112,6 +112,8 @@ void run_pw_backend_child(void) {
 		pw_buf = NULL;
 	}
 
+	pam_setcred(auth_handle, PAM_REFRESH_CRED);
+
 	if (pam_end(auth_handle, pam_status) != PAM_SUCCESS) {
 		swaylock_log(LOG_ERROR, "pam_end failed");
 		exit(EXIT_FAILURE);


### PR DESCRIPTION
I'm not entirely sure about this, but I think that `pam_setcred` should be called after successful authentication. In my case I need it to be able to use [pam-gnupg](https://github.com/cruegge/pam-gnupg) with swaylock so that I can unlock my gpg key everytime I unlock my sway session. I have also seen it being used in i3lock, albeit for a different reason: https://github.com/i3/i3lock/pull/9

The rationale seems to be that the program that needs the user's credentials needs to (quite logically) only get the correct credentials, `pam_authenticate` gets called each time that the user inputs a password (even if incorrect), while `pam_setcred` should only be called after a successful authentication.