### PR TITLE
Use explicit_bzero() if available

### DIFF
--- a/comm.c
+++ b/comm.c
@@ -91,7 +91,7 @@ bool write_comm_request(struct swaylock_password *pw) {
 	result = true;
 
 out:
-	explicit_bzero(pw, sizeof *pw);
+	explicit_bzero(pw, sizeof(*pw));
 	return result;
 }
 

--- a/comm.c
+++ b/comm.c
@@ -91,7 +91,7 @@ bool write_comm_request(struct swaylock_password *pw) {
 	result = true;
 
 out:
-	clear_password_buffer(pw);
+	explicit_bzero(pw, sizeof *pw);
 	return result;
 }
 

--- a/include/swaylock.h
+++ b/include/swaylock.h
@@ -2,6 +2,12 @@
 #define _SWAYLOCK_H
 #include <stdbool.h>
 #include <stdint.h>
+#ifdef HAVE_EXPLICIT_BZERO
+#include <string.h>
+#include <strings.h>
+#else
+void explicit_bzero(void *buf, size_t size);
+#endif
 #include <wayland-client.h>
 #include "background-image.h"
 #include "cairo.h"
@@ -133,6 +139,5 @@ void schedule_indicator_clear(struct swaylock_state *state);
 
 void initialize_pw_backend(int argc, char **argv);
 void run_pw_backend_child(void);
-void clear_buffer(char *buf, size_t size);
 
 #endif

--- a/meson.build
+++ b/meson.build
@@ -109,10 +109,7 @@ client_protos = declare_dependency(
 
 conf_data = configuration_data()
 conf_data.set10('HAVE_GDK_PIXBUF', gdk_pixbuf.found())
-
-if cc.has_function('explicit_bzero')
-	conf_data.set('HAVE_EXPLICIT_BZERO', 1)
-endif
+conf_data.set10('HAVE_EXPLICIT_BZERO', cc.has_function('explicit_bzero'))
 
 subdir('include')
 

--- a/meson.build
+++ b/meson.build
@@ -109,7 +109,10 @@ client_protos = declare_dependency(
 
 conf_data = configuration_data()
 conf_data.set10('HAVE_GDK_PIXBUF', gdk_pixbuf.found())
-conf_data.set10('HAVE_EXPLICIT_BZERO', cc.has_function('explicit_bzero'))
+
+conf_data.set10('HAVE_EXPLICIT_BZERO', cc.has_function('explicit_bzero', prefix : '''#include <string.h>
+#include <strings.h>
+#include <limits.h>''', args : '-D_GNU_SOURCE'))
 
 subdir('include')
 

--- a/meson.build
+++ b/meson.build
@@ -110,6 +110,10 @@ client_protos = declare_dependency(
 conf_data = configuration_data()
 conf_data.set10('HAVE_GDK_PIXBUF', gdk_pixbuf.found())
 
+if cc.has_function('explicit_bzero')
+	conf_data.set('HAVE_EXPLICIT_BZERO', 1)
+endif
+
 subdir('include')
 
 dependencies = [

--- a/pam.c
+++ b/pam.c
@@ -103,11 +103,11 @@ void run_pw_backend_child(void) {
 		}
 
 		if (!write_comm_reply(success)) {
-			clear_buffer(pw_buf, size);
+			explicit_bzero(pw_buf, size);
 			exit(EXIT_FAILURE);
 		}
 
-		clear_buffer(pw_buf, size);
+		explicit_bzero(pw_buf, size);
 		free(pw_buf);
 		pw_buf = NULL;
 	}

--- a/shadow.c
+++ b/shadow.c
@@ -83,24 +83,24 @@ void run_pw_backend_child(void) {
 		char *c = crypt(buf, encpw);
 		if (c == NULL) {
 			swaylock_log_errno(LOG_ERROR, "crypt failed");
-			clear_buffer(buf, size);
+			explicit_bzero(buf, size);
 			exit(EXIT_FAILURE);
 		}
 		bool success = strcmp(c, encpw) == 0;
 
 		if (!write_comm_reply(success)) {
-			clear_buffer(buf, size);
+			explicit_bzero(buf, size);
 			exit(EXIT_FAILURE);
 		}
 
 		// We don't want to keep it in memory longer than necessary,
 		// so clear *before* sleeping.
-		clear_buffer(buf, size);
+		explicit_bzero(buf, size);
 		free(buf);
 
 		sleep(2);
 	}
 
-	clear_buffer(encpw, strlen(encpw));
+	explicit_bzero(encpw, strlen(encpw));
 	exit(EXIT_SUCCESS);
 }


### PR DESCRIPTION
Use explicit_bzero() if available

The 'volatile' solution may not work as expected

Quote from https://www.gnu.org/software/libc/manual/html_node/Erasing-Sensitive-Data.html:

Declaring sensitive variables as volatile will make both the above problems worse; a volatile variable will be stored in memory for its entire lifetime, and the compiler will make more copies of it than it would otherwise have. Attempting to erase a normal variable “by hand” through a volatile-qualified pointer doesn’t work at all—because the variable itself is not volatile, some compilers will ignore the qualification on the pointer and remove the erasure anyway. 