### PR TITLE
Add -D/--dpms option to power off displays when idle

### DIFF
--- a/include/swaylock.h
+++ b/include/swaylock.h
@@ -8,6 +8,7 @@
 #include "pool-buffer.h"
 #include "seat.h"
 #include "wlr-layer-shell-unstable-v1-client-protocol.h"
+#include "wlr-output-power-management-unstable-v1-client-protocol.h"
 
 enum auth_state {
 	AUTH_STATE_IDLE,
@@ -63,6 +64,7 @@ struct swaylock_args {
 	bool show_failed_attempts;
 	bool daemonize;
 	bool indicator_idle_visible;
+	bool use_dpms;
 };
 
 struct swaylock_password {
@@ -89,6 +91,7 @@ struct swaylock_state {
 	int failed_attempts;
 	bool run_display;
 	struct zxdg_output_manager_v1 *zxdg_output_manager;
+	struct zwlr_output_power_manager_v1 *zwlr_output_power_manager;
 };
 
 struct swaylock_surface {
@@ -111,6 +114,9 @@ struct swaylock_surface {
 	enum wl_output_subpixel subpixel;
 	char *output_name;
 	struct wl_list link;
+	struct zwlr_output_power_v1 *wlr_output_power;
+	enum zwlr_output_power_v1_mode power_mode;
+	bool power_mode_pending;
 };
 
 // There is exactly one swaylock_image for each -i argument

--- a/meson.build
+++ b/meson.build
@@ -88,6 +88,7 @@ client_protocols = [
 	[wl_protocol_dir, 'unstable/xdg-output/xdg-output-unstable-v1.xml'],
 	['wlr-layer-shell-unstable-v1.xml'],
 	['wlr-input-inhibitor-unstable-v1.xml'],
+	['wlr-output-power-management-unstable-v1.xml'],
 ]
 
 foreach p : client_protocols

--- a/wlr-output-power-management-unstable-v1.xml
+++ b/wlr-output-power-management-unstable-v1.xml
@@ -1,0 +1,128 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<protocol name="wlr_output_power_management_unstable_v1">
+  <copyright>
+    Copyright © 2019 Purism SPC
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice (including the next
+    paragraph) shall be included in all copies or substantial portions of the
+    Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+  </copyright>
+
+  <description summary="Control power management modes of outputs">
+    This protocol allows clients to control power management modes
+    of outputs that are currently part of the compositor space. The
+    intent is to allow special clients like desktop shells to power
+    down outputs when the system is idle.
+
+    To modify outputs not currently part of the compositor space see
+    wlr-output-management.
+
+    Warning! The protocol described in this file is experimental and
+    backward incompatible changes may be made. Backward compatible changes
+    may be added together with the corresponding interface version bump.
+    Backward incompatible changes are done by bumping the version number in
+    the protocol and interface names and resetting the interface version.
+    Once the protocol is to be declared stable, the 'z' prefix and the
+    version number in the protocol and interface names are removed and the
+    interface version number is reset.
+  </description>
+
+  <interface name="zwlr_output_power_manager_v1" version="1">
+    <description summary="manager to create per-output power management">
+      This interface is a manager that allows creating per-output power
+      management mode controls.
+    </description>
+
+    <request name="get_output_power">
+      <description summary="get a power management for an output">
+        Create an output power management mode control that can be used to
+        adjust the power management mode for a given output.
+      </description>
+      <arg name="id" type="new_id" interface="zwlr_output_power_v1"/>
+      <arg name="output" type="object" interface="wl_output"/>
+    </request>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the manager">
+        All objects created by the manager will still remain valid, until their
+        appropriate destroy request has been called.
+      </description>
+    </request>
+  </interface>
+
+  <interface name="zwlr_output_power_v1" version="1">
+    <description summary="adjust power management mode for an output">
+      This object offers requests to set the power management mode of
+      an output.
+    </description>
+
+    <enum name="mode">
+      <entry name="off" value="0"
+             summary="Output is turned off."/>
+      <entry name="on" value="1"
+             summary="Output is turned on, no power saving"/>
+    </enum>
+
+    <enum name="error">
+      <entry name="invalid_mode" value="1" summary="nonexistent power save mode"/>
+    </enum>
+
+    <request name="set_mode">
+      <description summary="Set an outputs power save mode">
+        Set an output's power save mode to the given mode. The mode change
+        is effective immediately. If the output does not support the given
+        mode a failed event is sent.
+      </description>
+      <arg name="mode" type="uint" enum="mode" summary="the power save mode to set"/>
+    </request>
+
+    <event name="mode">
+      <description summary="Report a power management mode change">
+        Report the power management mode change of an output.
+
+        The mode event is sent after an output changed its power
+        management mode. The reason can be a client using set_mode or the
+        compositor deciding to change an output's mode.
+        This event is also sent immediately when the object is created
+        so the client is informed about the current power management mode.
+      </description>
+      <arg name="mode" type="uint" enum="mode"
+           summary="the output's new power management mode"/>
+    </event>
+
+    <event name="failed">
+      <description summary="object no longer valid">
+        This event indicates that the output power management mode control
+        is no longer valid. This can happen for a number of reasons,
+        including:
+        - The output doesn't support power management
+        - Another client already has exclusive power management mode control
+          for this output
+        - The output disappeared
+
+        Upon receiving this event, the client should destroy this object.
+      </description>
+    </event>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy this power management">
+        Destroys the output power management mode control object.
+      </description>
+    </request>
+  </interface>
+</protocol>


### PR DESCRIPTION
This option makes use of the new wlr-output-power-management protocol to power off displays when swaylock is idle (i.e. when the unlock indicator, if enabled, is not shown).

I'm not hopeful of this getting merged considering swaylock's reluctance to add new features, but (as explained in the commit message and repeated below) I believe this feature provides a significant benefit to the experience that is not possible without direct integration into swaylock:

This approach provides far more reliable DPMS control than the currently recommended solution, which is to use something above swaylock (e.g. swayidle) to coordinate swaylock invocation with a separate swaymsg invocation to control DPMS. Since swayidle is purely input-based and cannot inspect swaylock's state, it will inevitably either power up the screens when it shouldn't or fail to when it should. For example, if swayidle is set to turn on the screens on "resume," it will do so even if the only input was a mouse bump, modifier key press, or something else that swaylock ignores completely.