### PR TITLE
Fix a potential use-after-free

### DIFF
--- a/main.c
+++ b/main.c
@@ -102,6 +102,8 @@ static void destroy_surface(struct swaylock_surface *surface) {
 	}
 	destroy_buffer(&surface->buffers[0]);
 	destroy_buffer(&surface->buffers[1]);
+	destroy_buffer(&surface->indicator_buffers[0]);
+	destroy_buffer(&surface->indicator_buffers[1]);
 	wl_output_destroy(surface->output);
 	free(surface);
 }


### PR DESCRIPTION
I haven't looked too deep into exactly how the buffer system works, but from what I understand, there's an opportunity for a use-after-free if a `pool_buffer` is freed without calling `destroy_buffer`, if Wayland decides to send the `buffer_release` event after the `free` takes place. I don't know if this would ever happen in practice in swaylock, but in swaylock-effects, this issue would trigger a use-after-free if an output is destroyed while a fade-in animation is running.