### PR TITLE
Fix output-specific images when the output reappears after being disconnected

### DIFF
--- a/include/swaylock.h
+++ b/include/swaylock.h
@@ -110,7 +110,6 @@ struct swaylock_surface {
 	int32_t scale;
 	enum wl_output_subpixel subpixel;
 	char *output_name;
-	bool ready;
 	struct wl_list link;
 };
 

--- a/include/swaylock.h
+++ b/include/swaylock.h
@@ -104,6 +104,7 @@ struct swaylock_surface {
 	struct pool_buffer buffers[2];
 	struct pool_buffer indicator_buffers[2];
 	struct pool_buffer *current_buffer;
+	int events_pending;
 	bool frame_pending, dirty;
 	uint32_t width, height;
 	uint32_t indicator_width, indicator_height;

--- a/include/swaylock.h
+++ b/include/swaylock.h
@@ -104,7 +104,7 @@ struct swaylock_surface {
 	struct pool_buffer buffers[2];
 	struct pool_buffer indicator_buffers[2];
 	struct pool_buffer *current_buffer;
-	int events_pending;
+	bool ready;
 	bool frame_pending, dirty;
 	uint32_t width, height;
 	uint32_t indicator_width, indicator_height;

--- a/include/swaylock.h
+++ b/include/swaylock.h
@@ -110,6 +110,7 @@ struct swaylock_surface {
 	int32_t scale;
 	enum wl_output_subpixel subpixel;
 	char *output_name;
+	bool ready;
 	struct wl_list link;
 };
 

--- a/main.c
+++ b/main.c
@@ -173,8 +173,6 @@ static void create_layer_surface(struct swaylock_surface *surface) {
 		wl_region_destroy(region);
 	}
 
-	surface->ready = true;
-
 	wl_surface_commit(surface->surface);
 }
 
@@ -227,10 +225,6 @@ static const struct wl_callback_listener surface_frame_listener = {
 };
 
 void damage_surface(struct swaylock_surface *surface) {
-	if (!surface->ready) {
-		return;
-	}
-
 	surface->dirty = true;
 	if (surface->frame_pending) {
 		return;

--- a/main.c
+++ b/main.c
@@ -357,7 +357,6 @@ static void handle_global(void *data, struct wl_registry *registry,
 				&wl_output_interface, 3);
 		surface->output_global_name = name;
 		wl_output_add_listener(surface->output, &_wl_output_listener, surface);
-
 		wl_list_insert(&state->surfaces, &surface->link);
 
 		if (state->run_display) {

--- a/main.c
+++ b/main.c
@@ -1232,6 +1232,12 @@ int main(int argc, char **argv) {
 		create_layer_surface(surface);
 	}
 
+	wl_list_for_each(surface, &state.surfaces, link) {
+		while (surface->events_pending > 0) {
+			wl_display_roundtrip(state.display);
+		}
+	}
+
 	if (state.args.daemonize) {
 		wl_display_roundtrip(state.display);
 		daemonize();

--- a/main.c
+++ b/main.c
@@ -304,6 +304,17 @@ static void handle_xdg_output_name(void *data, struct zxdg_output_v1 *output,
 	struct swaylock_surface *surface = data;
 	surface->xdg_output = output;
 	surface->output_name = strdup(name);
+
+	if (surface->output_name != NULL) {
+		cairo_surface_t *new_image = select_image(surface->state, surface);
+		if (new_image != surface->image) {
+			surface->image = new_image;
+		}
+
+		if (--surface->events_pending == 0) {
+			initially_render_surface(surface);
+		}
+	}
 }
 
 static void handle_xdg_output_description(void *data, struct zxdg_output_v1 *output,
@@ -312,15 +323,7 @@ static void handle_xdg_output_description(void *data, struct zxdg_output_v1 *out
 }
 
 static void handle_xdg_output_done(void *data, struct zxdg_output_v1 *output) {
-	struct swaylock_surface *surface = data;
-	cairo_surface_t *new_image = select_image(surface->state, surface);
-	if (new_image != surface->image) {
-		surface->image = new_image;
-	}
-
-	if (--surface->events_pending == 0) {
-		initially_render_surface(surface);
-	}
+	// Who cares
 }
 
 struct zxdg_output_v1_listener _xdg_output_listener = {


### PR DESCRIPTION
When setting an image with `--image <output>:<path>`, the image used to fail to apply if the relevant output appears some time after swaylock executes. That's because the `zxdg_output_manager` stuff was only done from the initialization code in main, and `create_layer_surface` depends on the `output_name` property to find the right image, which is set by the `xdg_output_listener`.

One thing to note is that this patch adds a window of time where the surface exists, but hasn't been initialized. Before this patch, the event loop was blocked until the surface was ready, but now, `wl_display_roundtrip` is called _before_ the surface is initialized with `create_layer_surface`. This state is indicated with the new `surface->ready` property. From what I can tell, the only part which really needs to care is `damage_surface`, but someone more familiar with the code base should think through it.