### PR TITLE
Fix: Calculate buffer dimensions using scale factor

### DIFF
--- a/render.c
+++ b/render.c
@@ -311,6 +311,10 @@ void render_frame(struct swaylock_surface *surface) {
 			}
 		}
 
+		// Ensure buffer size is multiple of buffer scale - required by protocol
+		new_height += surface->scale - (new_height % surface->scale);
+		new_width += surface->scale - (new_width % surface->scale);
+
 		if (buffer_width != new_width || buffer_height != new_height) {
 			destroy_buffer(surface->current_buffer);
 			surface->indicator_width = new_width;


### PR DESCRIPTION
The box_padding is adjusted for the display scaling but the actual dimensions of the text were not. This caused the indicator ring to disappear in some circumstances where the buffer size would not suffice to hold the data. Multiplying both the font height as well as the text width by surface->scale fixes these buffer dimensions.

This fixes at least my reproduction of #183 and also using swaylock-effects https://github.com/mortie/swaylock-effects/issues/53