### PR TITLE
Fix indicator buffer not resizing after display powers off

### DIFF
--- a/render.c
+++ b/render.c
@@ -321,6 +321,7 @@ void render_frame(struct swaylock_surface *surface) {
 		surface->indicator_width = new_width;
 		surface->indicator_height = new_height;
 		render_frame(surface);
+		return;
 	}
 
 	wl_surface_set_buffer_scale(surface->child, surface->scale);

--- a/render.c
+++ b/render.c
@@ -310,17 +310,17 @@ void render_frame(struct swaylock_surface *surface) {
 				new_width = extents.width + 2 * box_padding;
 			}
 		}
+	}
 
-		// Ensure buffer size is multiple of buffer scale - required by protocol
-		new_height += surface->scale - (new_height % surface->scale);
-		new_width += surface->scale - (new_width % surface->scale);
+	// Ensure buffer size is multiple of buffer scale - required by protocol
+	new_height += surface->scale - (new_height % surface->scale);
+	new_width += surface->scale - (new_width % surface->scale);
 
-		if (buffer_width != new_width || buffer_height != new_height) {
-			destroy_buffer(surface->current_buffer);
-			surface->indicator_width = new_width;
-			surface->indicator_height = new_height;
-			render_frame(surface);
-		}
+	if (buffer_width != new_width || buffer_height != new_height) {
+		destroy_buffer(surface->current_buffer);
+		surface->indicator_width = new_width;
+		surface->indicator_height = new_height;
+		render_frame(surface);
 	}
 
 	wl_surface_set_buffer_scale(surface->child, surface->scale);


### PR DESCRIPTION
I am having the same issue as described in https://github.com/swaywm/swaylock/issues/194 where the indicator ring would not show up after my displayed powered off. I did some debugging, and I noticed that after my display powers off, the value for `swaylock_state.auth_state` would never change from 0 (AUTH_STATE_IDLE). It is not clear to me why this is the case. However, one side-effect of this that I noticed is that the `indicator_width` and `indicator_height` state values will never change from their initial value of 0 in this situation, as the buffer resize logic in `render_frame` is unreachable.

By moving the buffer resize logic outside of the block that checks whether to render the indicator, the indicator buffers are able to be resized correctly, and everything in `swaylock` seems to resume correct behavior after my display is powered back on (the indicator ring renders, the auth state changes correctly, etc).

I am not sure if this is the correct fix, but if it is not, perhaps some of the information here will be helpful.

One other random observation: if I make the indicator ring show up before my display powers off by pressing a key, then power my display off and on again, the indicator ring will display correctly (even without this fix).