### PR TITLE
Add documentation for input-clearing shortcuts

### DIFF
--- a/swaylock.1.scd
+++ b/swaylock.1.scd
@@ -189,6 +189,10 @@ Locks your Wayland session.
 *--text-wrong-color* <rrggbb[aa]>
 	Sets the color of the text when invalid.
 
+# MISC
+
+Text input can be cleared by pressing Escape, Ctrl+U, or Ctrl+C.
+
 # AUTHORS
 
 Maintained by Drew DeVault <sir@cmpwn.com>, who is assisted by other open


### PR DESCRIPTION
Pressing Escape, Ctrl+C, or Ctrl+U clears all input, but this is not mentioned anywhere in the documentation.