### PR TITLE
Avoid __FILE__ to keep build reproducible

### DIFF
--- a/include/log.h
+++ b/include/log.h
@@ -24,11 +24,15 @@ void swaylock_log_init(enum log_importance verbosity);
 void _swaylock_log(enum log_importance verbosity, const char *format, ...)
 	_ATTRIB_PRINTF(2, 3);
 
-const char *_swaylock_strip_path(const char *filepath);
+#ifdef SWAYLOCK_REL_SRC_DIR
+// strip prefix from __FILE__, leaving the path relative to the project root
+#define _SWAYLOCK_FILENAME ((const char *)__FILE__ + sizeof(SWAYLOCK_REL_SRC_DIR) - 1)
+#else
+#define _SWAYLOCK_FILENAME __FILE__
+#endif
 
 #define swaylock_log(verb, fmt, ...) \
-	_swaylock_log(verb, "[%s:%d] " fmt, _swaylock_strip_path(__FILE__), \
-			__LINE__, ##__VA_ARGS__)
+	_swaylock_log(verb, "[%s:%d] " fmt, _SWAYLOCK_FILENAME, __LINE__, ##__VA_ARGS__)
 
 #define swaylock_log_errno(verb, fmt, ...) \
 	swaylock_log(verb, fmt ": %s", ##__VA_ARGS__, strerror(errno))

--- a/log.c
+++ b/log.c
@@ -57,12 +57,3 @@ void _swaylock_log(enum log_importance verbosity, const char *fmt, ...) {
 
 	va_end(args);
 }
-
-const char *_swaylock_strip_path(const char *filepath) {
-	if (*filepath == '.') {
-		while (*filepath == '.' || *filepath == '/') {
-			++filepath;
-		}
-	}
-	return filepath;
-}

--- a/meson.build
+++ b/meson.build
@@ -60,6 +60,43 @@ if git.found()
 endif
 add_project_arguments('-DSWAYLOCK_VERSION=@0@'.format(version), language: 'c')
 
+# Compute the relative path used by compiler invocations.
+source_root = meson.current_source_dir().split('/')
+build_root = meson.global_build_root().split('/')
+relative_dir_parts = []
+i = 0
+in_prefix = true
+foreach p : build_root
+	if i >= source_root.length() or not in_prefix or p != source_root[i]
+		in_prefix = false
+		relative_dir_parts += '..'
+	endif
+	i += 1
+endforeach
+i = 0
+in_prefix = true
+foreach p : source_root
+	if i >= build_root.length() or not in_prefix or build_root[i] != p
+		in_prefix = false
+		relative_dir_parts += p
+	endif
+	i += 1
+endforeach
+relative_dir = join_paths(relative_dir_parts) + '/'
+
+# Strip relative path prefixes from the code if possible, otherwise hide them.
+if cc.has_argument('-fmacro-prefix-map=/prefix/to/hide=')
+	add_project_arguments(
+		'-fmacro-prefix-map=@0@='.format(relative_dir),
+		language: 'c',
+	)
+else
+	add_project_arguments(
+		'-DSWAYLOCK_REL_SRC_DIR="@0@"'.format(relative_dir),
+		language: 'c',
+	)
+endif
+
 wl_protocol_dir = wayland_protos.get_pkgconfig_variable('pkgdatadir')
 
 if wayland_client.version().version_compare('>=1.14.91')


### PR DESCRIPTION
 `__FILE__` makes builds non-reproducible. 
(https://github.com/swaywm/swayidle/pull/105#discussion_r742754664)

Solution is based on sway's: https://github.com/swaywm/sway/pull/4282