### PR TITLE
session-lock: Do not crash on connecting new output

### DIFF
--- a/main.c
+++ b/main.c
@@ -243,6 +243,11 @@ static const struct wl_callback_listener surface_frame_listener = {
 };
 
 void damage_surface(struct swaylock_surface *surface) {
+	if (surface->width == 0 || surface->height == 0) {
+		// Not yet configured
+		return;
+	}
+
 	surface->dirty = true;
 	if (surface->frame_pending) {
 		return;


### PR DESCRIPTION
The problem here was that a commit in reaction to wl_output::geometry
was made before the surface was configured, which is a protocol error
with ext-session-lock. See 65552.531 in the following log.

    [  65537.378] wl_registry@2.global(37, "wl_output", 4)
    [  65537.534]  -> wl_registry@2.bind(37, "wl_output", 3, new id [unknown]@21)
    [  65537.679]  -> wl_compositor@5.create_surface(new id wl_surface@19)
    [  65537.744]  -> wl_compositor@5.create_surface(new id wl_surface@23)
    [  65537.822]  -> wl_subcompositor@6.get_subsurface(new id wl_subsurface@24, wl_surface@23, wl_surface@19)
    [  65537.934]  -> wl_subsurface@24.set_sync()
    [  65537.973]  -> ext_session_lock_v1@3.get_lock_surface(new id ext_session_lock_surface_v1@25, wl_surface@19, wl_output@21)
    [  65538.086]  -> wl_compositor@5.create_region(new id wl_region@26)
    [  65538.148]  -> wl_region@26.add(0, 0, 2147483647, 2147483647)
    [  65538.275]  -> wl_surface@19.set_opaque_region(wl_region@26)
    [  65538.325]  -> wl_region@26.destroy()
    [  65538.383]  -> wl_display@1.sync(new id wl_callback@27)
    [  65551.781] wl_display@1.delete_id(26)
    [  65551.924] wl_display@1.delete_id(27)
    [  65551.971] wl_pointer@13.enter(839, wl_surface@15, 558.01562500, 785.66796875)
    [  65552.093]  -> wl_pointer@13.set_cursor(839, nil, 0, 0)
    [  65552.231] wl_output@21.geometry(0, 0, 440, 300, 0, "Samsung Electric Company", "SyncMaster", 0)
    [  65552.453]  -> wl_surface@19.frame(new id wl_callback@26)
    [  65552.531]  -> wl_surface@19.commit()
    [  65552.568] wl_output@21.mode(1, 1680, 1050, 59883)
    [  65552.685] wl_output@21.scale(1)
    [  65552.762] wl_output@21.done()
    [  65552.796] ext_session_lock_surface_v1@25.configure(840, 1680, 1050)
    [  65552.893]  -> ext_session_lock_surface_v1@25.ack_configure(840)
    [  65553.044]  -> wl_shm@4.create_pool(new id wl_shm_pool@28, fd 7, 7056000)
    [  65553.156]  -> wl_shm_pool@28.create_buffer(new id wl_buffer@29, 0, 1680, 1050, 6720, 0)
    [  65553.224]  -> wl_shm_pool@28.destroy()
    [  65558.903]  -> wl_surface@19.set_buffer_scale(1)
    [  65558.953]  -> wl_surface@19.attach(wl_buffer@29, 0, 0)
    [  65558.981]  -> wl_surface@19.damage_buffer(0, 0, 2147483647, 2147483647)
    [  65559.013]  -> wl_surface@19.commit()
    [  65559.026]  -> wl_subsurface@24.set_position(842, 465)
    [  65559.063]  -> wl_surface@23.attach(nil, 0, 0)
    [  65559.088]  -> wl_surface@23.commit()
    [  65559.110]  -> wl_subsurface@24.set_position(782, 465)
    [  65559.186]  -> wl_shm@4.create_pool(new id wl_shm_pool@30, fd 8, 58564)
    [  65559.220]  -> wl_shm_pool@30.create_buffer(new id wl_buffer@31, 0, 121, 121, 484, 0)
    [  65559.266]  -> wl_shm_pool@30.destroy()
    [  65559.287]  -> wl_surface@23.attach(nil, 0, 0)
    [  65559.316]  -> wl_surface@23.commit()
    [  65559.385]  -> wl_surface@23.set_buffer_scale(1)
    [  65559.402]  -> wl_surface@23.attach(wl_buffer@31, 0, 0)
    [  65559.427]  -> wl_surface@23.damage_buffer(0, 0, 2147483647, 2147483647)
    [  65559.458]  -> wl_surface@23.commit()
    [  65559.467]  -> wl_surface@19.commit()
    [  65559.478] wl_callback@27.done(840)
    [  65559.740] wl_display@1.error(ext_session_lock_surface_v1@25, 0, "session lock surface has never been configured")
    ext_session_lock_surface_v1@25: error 0: session lock surface has never been configured