### PR TITLE
seat: NULL-check on keyboard.modifiers event

### DIFF
--- a/seat.c
+++ b/seat.c
@@ -86,6 +86,10 @@ static void keyboard_modifiers(void *data, struct wl_keyboard *wl_keyboard,
 		uint32_t mods_locked, uint32_t group) {
 	struct swaylock_seat *seat = data;
 	struct swaylock_state *state = seat->state;
+	if (state->xkb.state == NULL) {
+		return;
+	}
+
 	int layout_same = xkb_state_layout_index_is_active(state->xkb.state,
 		group, XKB_STATE_LAYOUT_EFFECTIVE);
 	if (!layout_same) {


### PR DESCRIPTION
It can be sent before keyboard.keymap (for example
when running swaylock from a different tty), in
which case the xkb state isn't initialized yet.