### PR TITLE
Only process surface configure if size has changed

### DIFF
--- a/main.c
+++ b/main.c
@@ -181,6 +181,9 @@ static void layer_surface_configure(void *data,
 		struct zwlr_layer_surface_v1 *layer_surface,
 		uint32_t serial, uint32_t width, uint32_t height) {
 	struct swaylock_surface *surface = data;
+	if (surface->width == width && surface->height == height) {
+		return;
+	}
 	surface->width = width;
 	surface->height = height;
 	surface->indicator_width = 0;


### PR DESCRIPTION
I'm not sure why we're getting multiple `layer_surface_configure` callbacks in the first place, but this change ensures that we only respond to them if the surface size has actually changed.

This seems to fix #223 but I'm not exactly sure why.

I would also add this logic to `ext_session_lock_surface_v1_handle_configure` but I couldn't figure out how to get that protocol enabled for testing.

Before:
```
➜  swaylock-dpms-git git:(master) ✗ ninja -C build && ./build/swaylock --indicator-idle-visible
ninja: Entering directory `build'
[2/2] Linking target swaylock
layer_surface_configure: 22600, 1706, 960
layer_surface_configure done: 22600
layer_surface_configure: 22602, 1706, 960
layer_surface_configure done: 22602
layer_surface_configure: 22604, 1706, 960
layer_surface_configure done: 22604
layer_surface_configure: 22606, 1706, 960
layer_surface_configure done: 22606
layer_surface_configure: 22608, 1706, 960
layer_surface_configure done: 22608
layer_surface_configure: 22613, 1706, 960
layer_surface_configure done: 22613
surface_handle_frame_done
surface_handle_frame_done
surface_handle_frame_done
surface_handle_frame_done
surface_handle_frame_done
surface_handle_frame_done
surface_handle_frame_done
surface_handle_frame_done
surface_handle_frame_done
surface_handle_frame_done
```

After:
```
➜  swaylock-dpms-git git:(master) ✗ ninja -C build && ./build/swaylock --indicator-idle-visible -s solid_color
ninja: Entering directory `build'
[2/2] Linking target swaylock
layer_surface_configure: 23098, 1706, 960
layer_surface_configure done: 23098
layer_surface_configure: 23100, 1706, 960
layer_surface_configure: 23102, 1706, 960
layer_surface_configure done: 23102
layer_surface_configure: 23104, 1706, 960
layer_surface_configure: 23106, 1706, 960
layer_surface_configure: 23111, 1706, 960
surface_handle_frame_done
surface_handle_frame_done
surface_handle_frame_done
surface_handle_frame_done
surface_handle_frame_done
surface_handle_frame_done
surface_handle_frame_done
surface_handle_frame_done
surface_handle_frame_done
surface_handle_frame_done
surface_handle_frame_done
surface_handle_frame_done
surface_handle_frame_done
surface_handle_frame_done
surface_handle_frame_done
surface_handle_frame_done
```