### PR TITLE
Delete whole utf8 character on backspace

### DIFF
--- a/include/unicode.h
+++ b/include/unicode.h
@@ -10,6 +10,14 @@
 #define UTF8_INVALID 0x80
 
 /**
+ * Gets the size in bytes of the last utf8 character in a NULL terminated string
+ * This function does not validate that the buffer contains correct utf8 data;
+ * it merely looks for the first byte that correctly denotes the beginning of a
+ * utf8 character.
+ */
+int utf8_last_size(const char *str);
+
+/**
  * Grabs the next UTF-8 character and advances the string pointer
  */
 uint32_t utf8_decode(const char **str);

--- a/password.c
+++ b/password.c
@@ -28,7 +28,8 @@ void clear_password_buffer(struct swaylock_password *pw) {
 
 static bool backspace(struct swaylock_password *pw) {
 	if (pw->len != 0) {
-		pw->buffer[--pw->len] = 0;
+		pw->len -= utf8_last_size(pw->buffer);
+		pw->buffer[pw->len] = 0;
 		return true;
 	}
 	return false;

--- a/unicode.c
+++ b/unicode.c
@@ -1,6 +1,19 @@
 #include <stdint.h>
 #include <stddef.h>
+#include <string.h>
 #include "unicode.h"
+
+int utf8_last_size(const char *str) {
+	int len = 0;
+	char *pos = strchr(str, '\0');
+	while (pos > str) {
+		--pos; ++len;
+		if ((*pos & 0xc0) != 0x80) {
+			return len;
+		}
+	}
+	return 0;
+}
 
 size_t utf8_chsize(uint32_t ch) {
 	if (ch < 0x80) {


### PR DESCRIPTION
...rather than just the last byte of the password buffer.

Demostrate the need for this by taking the following steps:
- Apply the patch below (before this commit).
- Set keyboard layout to one where utf8 characters longer than one byte
  can be obtained, for example åäö using Swedish layout
  (XKB_DEFAULT_LAYOUT=se).
- Type "åäö" then press backspace and observe that it takes two
  backspaces to delete each character fully, and therefore six
  backspaces to fully clear the password buffer.

```
diff --git a/password.c b/password.c
index e1a1d9a..b640cd3 100644
--- a/password.c
+++ b/password.c
@@ -29,6 +29,7 @@ void clear_password_buffer(struct swaylock_password *pw) {
 static bool backspace(struct swaylock_password *pw) {
 	if (pw->len != 0) {
 		pw->buffer[--pw->len] = 0;
+		fprintf(stderr, "%s\n", pw->buffer);
 		return true;
 	}
 	return false;
```
