### PR TITLE
wayland-scanner: use native version to support cross-compilation

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -38,7 +38,9 @@ endif
 
 wayland_client = dependency('wayland-client', version: '>=1.20.0')
 wayland_protos = dependency('wayland-protocols', version: '>=1.25', fallback: 'wayland-protocols')
-wayland_scanner = dependency('wayland-scanner', version: '>=1.15.0')
+# use native version of wayland-scanner when cross-compiling
+# meson does this too: https://github.com/mesonbuild/meson/blob/c649a2b8c59c9f49affca9bd89c126bfa0f54449/mesonbuild/modules/unstable_wayland.py#L48-L53
+wayland_scanner = dependency('wayland-scanner', version: '>=1.15.0', native: true)
 xkbcommon = dependency('xkbcommon')
 cairo = dependency('cairo')
 gdk_pixbuf = dependency('gdk-pixbuf-2.0', required: get_option('gdk-pixbuf'))


### PR DESCRIPTION
Cross-compilation support was broken in https://github.com/swaywm/swaylock/commit/55c018a350d52efe7d0db168d15636b900dd9ce4 because wayland-scanner from the host system is used with that change.
This patch changes it back to use wayland-scanner from the build system.
For normal (non-cross) compilation this shouldn't change anything.

Meson also uses the build machine wayland-scanner binary:
- https://github.com/mesonbuild/meson/blob/c649a2b8c59c9f49affca9bd89c126bfa0f54449/mesonbuild/modules/unstable_wayland.py#L48-L53

I already tried this out on the latest version that's in nixpkgs and that fixes cross-compilation for me: https://github.com/mindavi/nixpkgs/commit/fa197c2ef53134017be48882987146bacbf6512c