### PR TITLE
Unlock the screen on SIGUSR1

### DIFF
--- a/loop.c
+++ b/loop.c
@@ -82,7 +82,7 @@ void loop_poll(struct loop *loop) {
 	}
 
 	int ret = poll(loop->fds, loop->fd_length, ms);
-	if (ret < 0) {
+	if (ret < 0 && errno != EINTR) {
 		swaylock_log_errno(LOG_ERROR, "poll failed");
 		exit(1);
 	}

--- a/main.c
+++ b/main.c
@@ -5,6 +5,7 @@
 #include <fcntl.h>
 #include <getopt.h>
 #include <poll.h>
+#include <signal.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -390,6 +391,12 @@ static const struct wl_registry_listener registry_listener = {
 	.global = handle_global,
 	.global_remove = handle_global_remove,
 };
+
+static int sigusr_fds[2] = {-1, -1};
+
+void do_sigusr(int sig) {
+	(void)write(sigusr_fds[1], "1", 1);
+}
 
 static cairo_surface_t *select_image(struct swaylock_state *state,
 		struct swaylock_surface *surface) {
@@ -1123,6 +1130,10 @@ static void comm_in(int fd, short mask, void *data) {
 	}
 }
 
+static void term_in(int fd, short mask, void *data) {
+	state.run_display = false;
+}
+
 int main(int argc, char **argv) {
 	swaylock_log_init(LOG_ERROR);
 	initialize_pw_backend(argc, argv);
@@ -1195,6 +1206,11 @@ int main(int argc, char **argv) {
 	}
 #endif
 
+	if (pipe(sigusr_fds) != 0) {
+		swaylock_log(LOG_ERROR, "Failed to pipe");
+		return 1;
+	}
+
 	wl_list_init(&state.surfaces);
 	state.xkb.context = xkb_context_new(XKB_CONTEXT_NO_FLAGS);
 	state.display = wl_display_connect(NULL);
@@ -1254,6 +1270,9 @@ int main(int argc, char **argv) {
 			display_in, NULL);
 
 	loop_add_fd(state.eventloop, get_comm_reply_fd(), POLLIN, comm_in, NULL);
+
+	loop_add_fd(state.eventloop, sigusr_fds[0], POLLIN, term_in, NULL);
+	signal(SIGUSR1, do_sigusr);
 
 	state.run_display = true;
 	while (state.run_display) {

--- a/swaylock.1.scd
+++ b/swaylock.1.scd
@@ -189,6 +189,11 @@ Locks your Wayland session.
 *--text-wrong-color* <rrggbb[aa]>
 	Sets the color of the text when invalid.
 
+# SIGNALS
+
+*SIGUSR1*
+	Unlock the screen and exit.
+
 # AUTHORS
 
 Maintained by Drew DeVault <sir@cmpwn.com>, who is assisted by other open


### PR DESCRIPTION
When the screen is locked using ext_session_lock, killing swaylock will
leave the session locked.  This is normally desirable if the kill is due
to the OOM killer or swaylock crashing, but can be undesirable if an
unlock is desired.  This adds a signal handler for SIGTERM if using
ext_session_lock without the --disable-unlock-on-sigterm option.