### PR TITLE
Accept input while validating

### DIFF
--- a/password.c
+++ b/password.c
@@ -95,10 +95,6 @@ static void submit_password(struct swaylock_state *state) {
 
 void swaylock_handle_key(struct swaylock_state *state,
 		xkb_keysym_t keysym, uint32_t codepoint) {
-	// Ignore input events if validating
-	if (state->auth_state == AUTH_STATE_VALIDATING) {
-		return;
-	}
 
 	switch (keysym) {
 	case XKB_KEY_KP_Enter: /* fallthrough */


### PR DESCRIPTION
Allow typing new input while the previous one is validating. Can be
tested with:

    ninja -C build && sway -c sway.conf

Where `sway.conf` is:

    exec ./build/swaylock

Fixes: https://github.com/swaywm/swaylock/issues/241