### PR TITLE
Fix loss of clarity with odd-sized centered image

### DIFF
--- a/background-image.c
+++ b/background-image.c
@@ -100,9 +100,14 @@ void render_background_image(cairo_t *cairo, cairo_surface_t *image,
 		break;
 	}
 	case BACKGROUND_MODE_CENTER:
+		/*
+		 * Align the unscaled image to integer pixel boundaries
+		 * in order to prevent loss of clarity (this only matters
+		 * for odd-sized images).
+		 */
 		cairo_set_source_surface(cairo, image,
-				(double)buffer_width / 2 - width / 2,
-				(double)buffer_height / 2 - height / 2);
+				(int)((double)buffer_width / 2 - width / 2),
+				(int)((double)buffer_height / 2 - height / 2));
 		break;
 	case BACKGROUND_MODE_TILE: {
 		cairo_pattern_t *pattern = cairo_pattern_create_for_surface(image);


### PR DESCRIPTION
When using `scaling=center`, an image with an odd width or height is currently shifted by 0.5 pixel relative to display pixels, resulting in a loss of detail when rendered. This is particular noticeable with an image containing text, which becomes noticeably blurry.

It's true that the current code is "accurate" in that it exactly centers the image on the display, but I think most users would probably prefer to live with the image being off-center by 0.5 pixel in return for pixel-perfect rendering.