### PR TITLE
Ensure that ext_session_lock_v1.unlock_and_destroy is processed.

### DIFF
--- a/main.c
+++ b/main.c
@@ -1285,7 +1285,7 @@ int main(int argc, char **argv) {
 
 	if (state.ext_session_lock_v1) {
 		ext_session_lock_v1_unlock_and_destroy(state.ext_session_lock_v1);
-		wl_display_flush(state.display);
+		wl_display_roundtrip(state.display);
 	}
 
 	free(state.args.font);


### PR DESCRIPTION
Use wl_display_roundtrip to ensure that the unlock request is received and processed by the server. The protocol requires[1] this to avoid possible races.

[1]: https://gitlab.freedesktop.org/wayland/wayland-protocols/-/merge_requests/161

Without the patch I regularly observed the red screen; WAYLAND_DEBUG output had no messages after unlock_and_destroy, so I assumed this was the cause. A month of testing with no unlock issues seems to be a good confirmation.