### PR TITLE
Refactor render_frame

### DIFF
--- a/include/swaylock.h
+++ b/include/swaylock.h
@@ -86,6 +86,8 @@ struct swaylock_state {
 	struct swaylock_args args;
 	struct swaylock_password password;
 	struct swaylock_xkb xkb;
+	cairo_surface_t *test_surface;
+	cairo_t *test_cairo; // used to estimate font/text sizes
 	enum auth_state auth_state;
 	int failed_attempts;
 	bool run_display;

--- a/include/swaylock.h
+++ b/include/swaylock.h
@@ -109,7 +109,6 @@ struct swaylock_surface {
 	struct pool_buffer indicator_buffers[2];
 	bool frame_pending, dirty;
 	uint32_t width, height;
-	uint32_t indicator_width, indicator_height;
 	int32_t scale;
 	enum wl_output_subpixel subpixel;
 	char *output_name;

--- a/main.c
+++ b/main.c
@@ -1291,6 +1291,9 @@ int main(int argc, char **argv) {
 		return 1;
 	}
 
+	state.test_surface = cairo_image_surface_create(CAIRO_FORMAT_RGB24, 1, 1);
+	state.test_cairo = cairo_create(state.test_surface);
+
 	struct swaylock_surface *surface;
 	wl_list_for_each(surface, &state.surfaces, link) {
 		create_surface(surface);
@@ -1325,5 +1328,7 @@ int main(int argc, char **argv) {
 	}
 
 	free(state.args.font);
+	cairo_destroy(state.test_cairo);
+	cairo_surface_destroy(state.test_surface);
 	return 0;
 }

--- a/main.c
+++ b/main.c
@@ -184,8 +184,6 @@ static void layer_surface_configure(void *data,
 	struct swaylock_surface *surface = data;
 	surface->width = width;
 	surface->height = height;
-	surface->indicator_width = 0;
-	surface->indicator_height = 0;
 	zwlr_layer_surface_v1_ack_configure(layer_surface, serial);
 	render_frame_background(surface);
 	render_frame(surface);
@@ -208,8 +206,6 @@ static void ext_session_lock_surface_v1_handle_configure(void *data,
 	struct swaylock_surface *surface = data;
 	surface->width = width;
 	surface->height = height;
-	surface->indicator_width = 0;
-	surface->indicator_height = 0;
 	ext_session_lock_surface_v1_ack_configure(lock_surface, serial);
 	render_frame_background(surface);
 	render_frame(surface);

--- a/render.c
+++ b/render.c
@@ -108,10 +108,6 @@ void render_frame(struct swaylock_surface *surface) {
 		return;
 	}
 
-	// Hide subsurface until we want it visible
-	wl_surface_attach(surface->child, NULL, 0, 0);
-	wl_surface_commit(surface->child);
-
 	cairo_t *cairo = buffer->cairo;
 	cairo_set_antialias(cairo, CAIRO_ANTIALIAS_BEST);
 	cairo_font_options_t *fo = cairo_font_options_create();


### PR DESCRIPTION
This PR reorganizes the `render_frame` function so that it no longer calls itself recursively. (This sometimes made swaybg render the same indicator twice.) To estimate font and text extents, it now uses a "test" cairo context based on a 1x1 surface.

The following additional patch can be used to make the buffer size visible:
```
diff --git a/render.c b/render.c
index 3ce7a80..3e5e6eb 100644
--- a/render.c
+++ b/render.c
@@ -211,7 +211,7 @@ void render_frame(struct swaylock_surface *surface) {
 
        // Clear
        cairo_save(cairo);
-       cairo_set_source_rgba(cairo, 0, 0, 0, 0);
+       cairo_set_source_rgba(cairo, 0, 0, 0, 0.5);
        cairo_set_operator(cairo, CAIRO_OPERATOR_SOURCE);
        cairo_paint(cairo);
        cairo_restore(cairo);
```