### PR TITLE
Fix option parsing without --debug after #261

### DIFF
--- a/main.c
+++ b/main.c
@@ -1148,7 +1148,7 @@ void log_init(int argc, char **argv) {
 	optind = 1;
     while (1) {
 		int opt_idx = 0;
-		c = getopt_long(argc, argv, "d", long_options, &opt_idx);
+		c = getopt_long(argc, argv, "-:d", long_options, &opt_idx);
 		if (c == -1) {
 			break;
 		}


### PR DESCRIPTION
Option parsing was messed up by #261 because `getopt_long` mutates `argv` by default, and it printed confusing error messages when `--debug` was not the first option. This PR fixes both of those issues

See https://github.com/swaywm/swaylock/pull/261#discussion_r1086819313

From getopt manual page:

> By default, getopt() permutes the contents of argv as it scans, so that eventually all the nonoptions are at the end. Two other scanning modes are also implemented. [...] If the first character of optstring is '-', then each nonoption argv-element is handled as if it were the argument of an option with character code 1.

> If the first character (following any optional '+' or '-' described above) of optstring is a colon (':'), then getopt() likewise does not print an error message. In addition, it returns ':' instead of '?' to indicate a missing option argument. This allows the caller to distinguish the two different types of errors.