### PR TITLE
Wait for the locked event

### DIFF
--- a/include/swaylock.h
+++ b/include/swaylock.h
@@ -90,7 +90,7 @@ struct swaylock_state {
 	cairo_t *test_cairo; // used to estimate font/text sizes
 	enum auth_state auth_state;
 	int failed_attempts;
-	bool run_display;
+	bool run_display, locked;
 	struct ext_session_lock_manager_v1 *ext_session_lock_manager_v1;
 	struct ext_session_lock_v1 *ext_session_lock_v1;
 };


### PR DESCRIPTION
We were ignoring the locked event. Wait for it instead.