### PR TITLE
Add --ready-fd 

### DIFF
--- a/include/swaylock.h
+++ b/include/swaylock.h
@@ -62,6 +62,7 @@ struct swaylock_args {
 	bool hide_keyboard_layout;
 	bool show_failed_attempts;
 	bool daemonize;
+	int ready_fd;
 	bool indicator_idle_visible;
 };
 


### PR DESCRIPTION
This implements a readiness notification mechanism which works on
both systemd and s6.

References: https://github.com/swaywm/swaylock/pull/42
References: https://github.com/swaywm/swaylock/pull/275

~~Depends on #280~~