### PR TITLE
Fingerprint support

### DIFF
--- a/completions/bash/swaylock
+++ b/completions/bash/swaylock
@@ -14,6 +14,7 @@ _swaylock()
     -F
     -h
     -i
+    -p
     -k
     -K
     -L
@@ -41,6 +42,7 @@ _swaylock()
     --hide-keyboard-layout
     --ignore-empty-password
     --image
+    --fingerprint
     --indicator-caps-lock
     --indicator-idle-visible
     --indicator-radius

--- a/completions/fish/swaylock.fish
+++ b/completions/fish/swaylock.fish
@@ -14,6 +14,7 @@ complete -c swaylock -l help                   -s h --description "Show help mes
 complete -c swaylock -l hide-keyboard-layout   -s K --description "Hide the current xkb layout while typing."
 complete -c swaylock -l ignore-empty-password  -s e --description "When an empty password is provided, do not validate it."
 complete -c swaylock -l image                  -s i --description "Display the given image, optionally only on the given output."
+complete -c swaylock -l fingerprint               p --description "Enable fingerprint scanning. Fprint is required."
 complete -c swaylock -l indicator-caps-lock    -s l --description "Show the current Caps Lock state also on the indicator."
 complete -c swaylock -l indicator-idle-visible      --description "Sets the indicator to show even if idle."
 complete -c swaylock -l indicator-radius            --description "Sets the indicator radius."

--- a/completions/zsh/_swaylock
+++ b/completions/zsh/_swaylock
@@ -18,6 +18,7 @@ _arguments -s \
 	'(--hide-keyboard-layout -K)'{--hide-keyboard-layout,-K}'[Hide the current xkb layout while typing]' \
 	'(--ignore-empty-password -e)'{--ignore-empty-password,-e}'[When an empty password is provided, do not validate it]' \
 	'(--image -i)'{--image,-i}'[Display the given image, optionally only on the given output]:filename:_files' \
+	'(--fingerprint -p)'{--fingerprint,-p}'[Enable fingerprint scanning. Fprint is required]' \
 	'(--indicator-caps-lock -l)'{--indicator-caps-lock,-l}'[Show the current Caps Lock state also on the indicator]' \
 	'(--indicator-idle-visible)'--indicator-idle-visible'[Sets the indicator to show even if idle]' \
 	'(--indicator-radius)'--indicator-radius'[Sets the indicator radius]:radius:' \

--- a/fingerprint/fingerprint.c
+++ b/fingerprint/fingerprint.c
@@ -1,0 +1,261 @@
+/*
+ * Based on fprintd example to verify a fingerprint
+ * Copyright (C) 2008 Daniel Drake <dsd@gentoo.org>
+ * Copyright (C) 2020 Marco Trevisan <marco.trevisan@canonical.com>
+ * Copyright (C) 2022 Alexandr Lutsai <s.lyra@ya.ru>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <locale.h>
+#include <gio/gio.h>
+
+#include "fingerprint.h"
+#include "fingerprint/fprintd-dbus.h"
+
+static FprintDBusManager *manager = NULL;
+static GDBusConnection *connection = NULL;
+static gboolean g_fatal_warnings = FALSE;
+static FprintDBusDevice *device = NULL;
+
+static void
+create_manager (void)
+{
+    g_autoptr(GError) error = NULL;
+
+    connection = g_bus_get_sync (G_BUS_TYPE_SYSTEM, NULL, &error);
+    if (connection == NULL)
+    {
+        g_print ("Failed to connect to session bus: %s\n", error->message);
+        return;
+    }
+
+    manager = fprint_dbus_manager_proxy_new_sync (connection,
+                                                  G_DBUS_PROXY_FLAGS_NONE,
+                                                  "net.reactivated.Fprint",
+                                                  "/net/reactivated/Fprint/Manager",
+                                                  NULL, &error);
+    if (manager == NULL)
+    {
+        g_print ("Failed to get Fprintd manager: %s\n", error->message);
+        return;
+    }
+}
+
+static FprintDBusDevice *
+open_device (const char *username)
+{
+    g_autoptr(FprintDBusDevice) dev = NULL;
+    g_autoptr(GError) error = NULL;
+    g_autofree char *path = NULL;
+
+    if (!fprint_dbus_manager_call_get_default_device_sync (manager, &path,
+                                                           NULL, &error))
+    {
+        g_print ("Impossible to verify: %s\n", error->message);
+        return NULL;
+    }
+
+    g_print ("Using device %s\n", path);
+
+    dev = fprint_dbus_device_proxy_new_sync (connection,
+                                             G_DBUS_PROXY_FLAGS_NONE,
+                                             "net.reactivated.Fprint",
+                                             path, NULL, &error);
+
+    if (error)
+    {
+        g_print ("failed to connect to device: %s\n", error->message);
+        return NULL;
+    }
+
+    if (!fprint_dbus_device_call_claim_sync (dev, username, NULL, &error))
+    {
+        g_print ("failed to claim device: %s\n", error->message);
+        return NULL;
+    }
+
+    return g_steal_pointer (&dev);
+}
+
+struct VerifyState
+{
+    GError  *error;
+    gboolean started;
+    gboolean completed;
+    gboolean match;
+};
+
+static void
+verify_result (GObject *object, const char *result, gboolean done, void *user_data)
+{
+    struct VerifyState *verify_state = user_data;
+
+    g_print ("Verify result: %s (%s)\n", result, done ? "done" : "not done");
+    verify_state->match = g_str_equal (result, "verify-match");
+
+    if (done != FALSE) {
+        verify_state->completed = TRUE;
+        g_autoptr(GError) error = NULL;
+        if (!fprint_dbus_device_call_verify_stop_sync (device, NULL, &error))
+        {
+            g_print ("VerifyStop failed: %s\n", error->message);
+        }
+    }
+}
+
+static void
+verify_finger_selected (GObject *object, const char *name, void *user_data)
+{
+    g_print ("Verifying: %s\n", name);
+}
+
+static void
+verify_started_cb (GObject      *obj,
+                   GAsyncResult *res,
+                   gpointer      user_data)
+{
+    struct VerifyState *verify_state = user_data;
+
+    if (fprint_dbus_device_call_verify_start_finish (FPRINT_DBUS_DEVICE (obj), res, &verify_state->error))
+    {
+        g_print ("Verify started!\n");
+        verify_state->started = TRUE;
+    }
+}
+
+static void
+proxy_signal_cb (GDBusProxy  *proxy,
+                 const gchar *sender_name,
+                 const gchar *signal_name,
+                 GVariant    *parameters,
+                 gpointer     user_data)
+{
+    struct VerifyState *verify_state = user_data;
+
+    if (!verify_state->started)
+        return;
+
+    if (g_str_equal (signal_name, "VerifyStatus"))
+    {
+        const gchar *result;
+        gboolean done;
+
+        g_variant_get (parameters, "(&sb)", &result, &done);
+        verify_result (G_OBJECT (proxy), result, done, user_data);
+    }
+    else if (g_str_equal (signal_name, "VerifyFingerSelected"))
+    {
+        const gchar *name;
+
+        g_variant_get (parameters, "(&s)", &name);
+        verify_finger_selected (G_OBJECT (proxy), name, user_data);
+    }
+}
+
+static struct VerifyState verify_state = { 0 };
+static void
+start_verify (FprintDBusDevice *dev)
+{
+    /* This one is funny. We connect to the signal immediately to avoid
+     * race conditions. However, we must ignore any authentication results
+     * that happen before our start call returns.
+     * This is because the verify call itself may internally try to verify
+     * against fprintd (possibly using a separate account).
+     *
+     * To do so, we *must* use the async version of the verify call, as the
+     * sync version would cause the signals to be queued and only processed
+     * after it returns.
+     */
+
+    g_signal_connect (dev, "g-signal", G_CALLBACK (proxy_signal_cb),
+                      &verify_state);
+
+    fprint_dbus_device_call_verify_start (dev, "any", NULL,
+                                          verify_started_cb,
+                                          &verify_state);
+
+    /* Wait for verify start while discarding any VerifyStatus signals */
+    while (!verify_state.started && !verify_state.error)
+        g_main_context_iteration (NULL, TRUE);
+
+    if (verify_state.error)
+    {
+        g_print ("VerifyStart failed: %s\n", verify_state.error->message);
+        g_clear_error (&verify_state.error);
+        return;
+    }
+}
+
+static void
+release_device (FprintDBusDevice *dev)
+{
+    g_autoptr(GError) error = NULL;
+    if (!fprint_dbus_device_call_release_sync (dev, NULL, &error))
+    {
+        g_print ("ReleaseDevice failed: %s\n", error->message);
+    }
+}
+
+void fingerprint_init ( void )
+{
+    if (g_fatal_warnings)
+    {
+        GLogLevelFlags fatal_mask;
+
+        fatal_mask = g_log_set_always_fatal (G_LOG_FATAL_MASK);
+        fatal_mask |= G_LOG_LEVEL_WARNING | G_LOG_LEVEL_CRITICAL;
+        g_log_set_always_fatal (fatal_mask);
+    }
+
+    create_manager ();
+    if(manager == NULL || connection == NULL) {
+        return;
+    }
+    device = open_device ("");
+    if(device == NULL) {
+        return;
+    }
+
+    start_verify(device);
+}
+
+void fingerprint_deinit ( void ) {
+    if(device) {
+        release_device (device);
+    }
+}
+
+int fingerprint_verify ( void ) {
+    /* VerifyStatus signals are processing, do not wait for completion. */
+    g_main_context_iteration (NULL, FALSE);
+    if(manager == NULL || connection == NULL || device == NULL) {
+        return false;
+    }
+
+    if(!verify_state.completed) {
+        return false;
+    }
+
+    g_signal_handlers_disconnect_by_func (device, proxy_signal_cb,
+                                          &verify_state);
+    release_device (device);
+    device = NULL;
+    return true;
+}

--- a/fingerprint/fingerprint.c
+++ b/fingerprint/fingerprint.c
@@ -1,8 +1,8 @@
 /*
- * Based on fprintd example to verify a fingerprint
+ * Based on fprintd util to verify a fingerprint
  * Copyright (C) 2008 Daniel Drake <dsd@gentoo.org>
  * Copyright (C) 2020 Marco Trevisan <marco.trevisan@canonical.com>
- * Copyright (C) 2022 Alexandr Lutsai <s.lyra@ya.ru>
+ * Copyright (C) 2023 Alexandr Lutsai <s.lyra@ya.ru>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -27,211 +27,139 @@
 #include <gio/gio.h>
 
 #include "fingerprint.h"
-#include "fingerprint/fprintd-dbus.h"
-#include "swaylock.h"
+#include "log.h"
 
-static FprintDBusManager *manager = NULL;
-static GDBusConnection *connection = NULL;
-static gboolean g_fatal_warnings = FALSE;
-static FprintDBusDevice *device = NULL;
-struct swaylock_state *sw_state = NULL;
+static void display_message(struct FingerprintState *state, const char *fmt, ...) {
+    va_list(args);
+    va_start(args, fmt);
+    vsnprintf(state->status, sizeof(state->status), fmt, args);
+    va_end(args);
 
-static char fp_str[128] = {0};
-char * get_fp_string() {
-    return fp_str;
+    state->sw_state->auth_state = AUTH_STATE_FINGERPRINT;
+    state->sw_state->fingerprint_msg = state->status;
+    damage_state(state->sw_state);
+    schedule_indicator_clear(state->sw_state);
 }
 
-
-static void
-create_manager (void)
-{
+static void create_manager(struct FingerprintState *state) {
     g_autoptr(GError) error = NULL;
-
-    connection = g_bus_get_sync (G_BUS_TYPE_SYSTEM, NULL, &error);
-    if (connection == NULL)
-    {
-        snprintf(fp_str, sizeof(fp_str), "Failed to connect to session bus: %s\n", error->message);
-        sw_state->auth_state = AUTH_STATE_FINGERPRINT;
-        sw_state->fingerprint_msg = fp_str;
-        damage_state(sw_state);
-        schedule_indicator_clear(sw_state);
-        g_print ("%s\n", fp_str);
+    state->connection = g_bus_get_sync (G_BUS_TYPE_SYSTEM, NULL, &error);
+    if (state->connection == NULL) {
+        swaylock_log(LOG_ERROR, "Failed to connect to session bus: %s", error->message);
+        display_message(state, "Fingerprint error");
         return;
     }
 
-    manager = fprint_dbus_manager_proxy_new_sync (connection,
-                                                  G_DBUS_PROXY_FLAGS_NONE,
-                                                  "net.reactivated.Fprint",
-                                                  "/net/reactivated/Fprint/Manager",
-                                                  NULL, &error);
-
-    if (manager == NULL)
-    {
-        snprintf(fp_str, sizeof(fp_str), "Failed to get Fprintd manager: %s\n", error->message);
-        sw_state->auth_state = AUTH_STATE_FINGERPRINT;
-        sw_state->fingerprint_msg = fp_str;
-        damage_state(sw_state);
-        schedule_indicator_clear(sw_state);
-        g_print ("%s\n", fp_str);
+    state->manager = fprint_dbus_manager_proxy_new_sync(
+        state->connection,
+        G_DBUS_PROXY_FLAGS_NONE,
+        "net.reactivated.Fprint",
+        "/net/reactivated/Fprint/Manager",
+        NULL, &error);
+    if (state->manager == NULL) {
+        swaylock_log(LOG_ERROR, "Failed to get Fprintd manager: %s", error->message);
+        display_message(state, "Fingerprint error");
         return;
     }
 }
 
-static FprintDBusDevice *
-open_device (const char *username)
-{
+static void open_device(struct FingerprintState *state, const char *username) {
+    state->device = NULL;
     g_autoptr(FprintDBusDevice) dev = NULL;
     g_autoptr(GError) error = NULL;
     g_autofree char *path = NULL;
-
-    if (!fprint_dbus_manager_call_get_default_device_sync (manager, &path,
-                                                           NULL, &error))
-    {
-        snprintf(fp_str, sizeof(fp_str), "Impossible to verify: %s\n", error->message);
-        sw_state->auth_state = AUTH_STATE_FINGERPRINT;
-        sw_state->fingerprint_msg = fp_str;
-        damage_state(sw_state);
-        schedule_indicator_clear(sw_state);
-        g_print ("%s\n", fp_str);
-        return NULL;
-    }
-
-    snprintf(fp_str, sizeof(fp_str), "Using device %s\n", path);
-    sw_state->auth_state = AUTH_STATE_FINGERPRINT;
-        sw_state->fingerprint_msg = fp_str;
-        damage_state(sw_state);
-        schedule_indicator_clear(sw_state);
-    g_print ("%s\n", fp_str);
-
-    dev = fprint_dbus_device_proxy_new_sync (connection,
-                                             G_DBUS_PROXY_FLAGS_NONE,
-                                             "net.reactivated.Fprint",
-                                             path, NULL, &error);
-
-    if (error)
-    {
-        snprintf(fp_str, sizeof(fp_str), "failed to connect to device: %s\n", error->message);
-        sw_state->auth_state = AUTH_STATE_FINGERPRINT;
-        sw_state->fingerprint_msg = fp_str;
-        damage_state(sw_state);
-        schedule_indicator_clear(sw_state);
-        g_print ("%s\n", fp_str);
-        return NULL;
-    }
-
-    if (!fprint_dbus_device_call_claim_sync (dev, username, NULL, &error))
-    {
-        snprintf(fp_str, sizeof(fp_str), "failed to claim device: %s\n", error->message);
-        sw_state->auth_state = AUTH_STATE_FINGERPRINT;
-        sw_state->fingerprint_msg = fp_str;
-        damage_state(sw_state);
-        schedule_indicator_clear(sw_state);
-        g_print ("%s\n", fp_str);
-        return NULL;
-    }
-
-    const gchar * str = fprint_dbus_device_get_name(dev);
-    g_print("name name: %s\n", str);
-
-    return g_steal_pointer (&dev);
-}
-
-struct VerifyState
-{
-    GError  *error;
-    gboolean started;
-    gboolean completed;
-    gboolean match;
-};
-
-static void
-verify_result (GObject *object, const char *result, gboolean done, void *user_data)
-{
-    struct VerifyState *verify_state = user_data;
-
-    size_t o = snprintf(fp_str, sizeof(fp_str), "Verify result: %s (%s)", result, done ? "done" : "not done");
-    sw_state->auth_state = AUTH_STATE_FINGERPRINT;
-        sw_state->fingerprint_msg = fp_str;
-        damage_state(sw_state);
-        schedule_indicator_clear(sw_state);
-    g_print ("%lu %s\n", o, fp_str);
-    verify_state->match = g_str_equal (result, "verify-match");
-
-    if(g_str_equal (result, "verify-retry-scan")) {
+    if (!fprint_dbus_manager_call_get_default_device_sync(state->manager, &path, NULL, &error)) {
+        swaylock_log(LOG_ERROR, "Impossible to verify: %s", error->message);
+        display_message(state, "Fingerprint error");
         return;
     }
 
+    swaylock_log(LOG_DEBUG, "Fingerprint: using device %s", path);
+    dev = fprint_dbus_device_proxy_new_sync(
+        state->connection,
+        G_DBUS_PROXY_FLAGS_NONE,
+        "net.reactivated.Fprint",
+        path, NULL, &error);
+    if (error) {
+        swaylock_log(LOG_ERROR, "failed to connect to device: %s", error->message);
+        display_message(state, "Fingerprint error");
+        return;
+    }
+
+    if (!fprint_dbus_device_call_claim_sync(dev, username, NULL, &error)) {
+        swaylock_log(LOG_ERROR, "failed to claim the device: %s", error->message);
+        display_message(state, "Fingerprint error");
+        return;
+    }
+
+    state->device = g_steal_pointer (&dev);
+}
+
+static void verify_result(GObject *object, const char *result, gboolean done, void *user_data) {
+    struct FingerprintState *state = user_data;
+    swaylock_log(LOG_INFO, "Verify result: %s (%s)", result, done ? "done" : "not done");
+    state->match = g_str_equal (result, "verify-match");
+    if (g_str_equal (result, "verify-retry-scan")) {
+        display_message(state, "Retry");
+        return;
+    } else if(g_str_equal (result, "verify-swipe-too-short")) {
+        display_message(state, "Retry, too short");
+        return;
+    } else if(g_str_equal (result, "verify-finger-not-centered")) {
+        display_message(state, "Retry, not centered");
+        return;
+    } else if(g_str_equal (result, "verify-remove-and-retry")) {
+        display_message(state, "Remove and retry");
+        return;
+    }
+
+    if(state->match) {
+        display_message(state, "Fingerprint OK");
+    } else {
+        display_message(state, "Retry");
+    }
+
+    state->completed = TRUE;
     g_autoptr(GError) error = NULL;
-    if (!fprint_dbus_device_call_verify_stop_sync (device, NULL, &error))
-    {
-        snprintf(fp_str, sizeof(fp_str), "VerifyStop failed: %s\n", error->message);
-        sw_state->auth_state = AUTH_STATE_FINGERPRINT;
-        sw_state->fingerprint_msg = fp_str;
-        damage_state(sw_state);
-        schedule_indicator_clear(sw_state);
-    }
-    verify_state->completed = TRUE;
-}
-
-static void
-verify_finger_selected (GObject *object, const char *name, void *user_data)
-{
-    //snprintf(fp_str, sizeof(fp_str), "Verifying: %s\n", name);
-    //g_print ("Verifying: %s\n", name);
-}
-
-static void
-verify_started_cb (GObject      *obj,
-                   GAsyncResult *res,
-                   gpointer      user_data)
-{
-    struct VerifyState *verify_state = user_data;
-
-    if (fprint_dbus_device_call_verify_start_finish (FPRINT_DBUS_DEVICE (obj), res, &verify_state->error))
-    {
-        snprintf(fp_str, sizeof(fp_str), "Verify started!\n");
-        sw_state->auth_state = AUTH_STATE_FINGERPRINT;
-        sw_state->fingerprint_msg = fp_str;
-        damage_state(sw_state);
-        schedule_indicator_clear(sw_state);
-        g_print ("%s\n", fp_str);
-        verify_state->started = TRUE;
-    }
-}
-
-static void
-proxy_signal_cb (GDBusProxy  *proxy,
-                 const gchar *sender_name,
-                 const gchar *signal_name,
-                 GVariant    *parameters,
-                 gpointer     user_data)
-{
-    struct VerifyState *verify_state = user_data;
-
-    if (!verify_state->started)
+    if (!fprint_dbus_device_call_verify_stop_sync(state->device, NULL, &error)) {
+        swaylock_log(LOG_ERROR, "VerifyStop failed: %s", error->message);
+        display_message(state, "Fingerprint error");
         return;
-
-    if (g_str_equal (signal_name, "VerifyStatus"))
-    {
-        const gchar *result;
-        gboolean done;
-
-        g_variant_get (parameters, "(&sb)", &result, &done);
-        verify_result (G_OBJECT (proxy), result, done, user_data);
-    }
-    else if (g_str_equal (signal_name, "VerifyFingerSelected"))
-    {
-        const gchar *name;
-
-        g_variant_get (parameters, "(&s)", &name);
-        verify_finger_selected (G_OBJECT (proxy), name, user_data);
     }
 }
 
-static struct VerifyState verify_state = { 0 };
-static void
-start_verify (FprintDBusDevice *dev)
+static void verify_started_cb(GObject *obj, GAsyncResult *res, gpointer user_data) {
+    struct FingerprintState *state = user_data;
+    if (!fprint_dbus_device_call_verify_start_finish(FPRINT_DBUS_DEVICE(obj), res, &state->error)) {
+        return;
+    }
+
+    swaylock_log(LOG_DEBUG, "Verify started!");
+    state->started = TRUE;
+}
+
+static void proxy_signal_cb(GDBusProxy  *proxy,
+                            const gchar *sender_name,
+                            const gchar *signal_name,
+                            GVariant    *parameters,
+                            gpointer     user_data)
 {
+    struct FingerprintState *state = user_data;
+    if (!state->started) {
+        return;
+    }
+
+    if (!g_str_equal(signal_name, "VerifyStatus")) {
+        return;
+    }
+
+    const gchar *result;
+    gboolean done;
+    g_variant_get(parameters, "(&sb)", &result, &done);
+    verify_result(G_OBJECT (proxy), result, done, user_data);
+}
+
+static void start_verify(struct FingerprintState *state) {
     /* This one is funny. We connect to the signal immediately to avoid
      * race conditions. However, we must ignore any authentication results
      * that happen before our start call returns.
@@ -242,97 +170,75 @@ start_verify (FprintDBusDevice *dev)
      * sync version would cause the signals to be queued and only processed
      * after it returns.
      */
-
-    fprint_dbus_device_call_verify_start (dev, "any", NULL,
-                                          verify_started_cb,
-                                          &verify_state);
+    fprint_dbus_device_call_verify_start(state->device, "any", NULL,
+                                         verify_started_cb,
+                                         state);
 
     /* Wait for verify start while discarding any VerifyStatus signals */
-    while (!verify_state.started && !verify_state.error)
-        g_main_context_iteration (NULL, TRUE);
+    while (!state->started && !state->error) {
+        g_main_context_iteration(NULL, TRUE);
+    }
 
-    if (verify_state.error)
-    {
-        snprintf(fp_str, sizeof(fp_str), "VerifyStart failed: %s\n", verify_state.error->message);
-        sw_state->auth_state = AUTH_STATE_FINGERPRINT;
-        sw_state->fingerprint_msg = fp_str;
-        damage_state(sw_state);
-        schedule_indicator_clear(sw_state);
-        g_print ("%s\n", fp_str);
-        g_clear_error (&verify_state.error);
+    if (state->error) {
+        swaylock_log(LOG_ERROR, "VerifyStart failed: %s", state->error->message);
+        display_message(state, "Fingerprint error");
+        g_clear_error(&state->error);
         return;
     }
 }
 
-static void release_callback(GObject *source_object,
-                             GAsyncResult *res,
+static void release_callback(GObject *source_object, GAsyncResult *res,
                              gpointer user_data) {
-    //g_print ("ReleaseDevice failed: %s\n", error->message);
 }
 
-static void
-release_device (FprintDBusDevice *dev)
-{
-    fprint_dbus_device_call_release (dev, NULL, release_callback, NULL);
-}
-
-void fingerprint_init ( struct swaylock_state *state )
-{
-    sw_state = state;
-    if (g_fatal_warnings)
-    {
-        GLogLevelFlags fatal_mask;
-
-        fatal_mask = g_log_set_always_fatal (G_LOG_FATAL_MASK);
-        fatal_mask |= G_LOG_LEVEL_WARNING | G_LOG_LEVEL_CRITICAL;
-        g_log_set_always_fatal (fatal_mask);
-    }
-
-    create_manager ();
-    if(manager == NULL || connection == NULL) {
+void fingerprint_init(struct FingerprintState *fingerprint_state,
+                      struct swaylock_state *swaylock_state) {
+    memset(fingerprint_state, 0, sizeof(struct FingerprintState));
+    fingerprint_state->sw_state = swaylock_state;
+    create_manager(fingerprint_state);
+    if(fingerprint_state->manager == NULL || fingerprint_state->connection == NULL) {
         return;
     }
-    device = open_device ("");
-    if(device == NULL) {
+    open_device(fingerprint_state, "");
+    if(fingerprint_state->device == NULL) {
         return;
     }
-    g_signal_connect (device, "g-signal", G_CALLBACK (proxy_signal_cb),
-                      &verify_state);
-    start_verify(device);
+
+    g_signal_connect (fingerprint_state->device, "g-signal", G_CALLBACK (proxy_signal_cb),
+                      fingerprint_state);
+    start_verify(fingerprint_state);
 }
 
-void fingerprint_deinit ( void ) {
-    g_print("rel\n");
-    if(device) {
-        g_signal_handlers_disconnect_by_func (device, proxy_signal_cb,
-                                              &verify_state);
-        release_device (device);
-        device = NULL;
-    }
-}
-
-int fingerprint_verify ( struct swaylock_state *state ) {
-    sw_state = state;
+int fingerprint_verify(struct FingerprintState *fingerprint_state) {
     /* VerifyStatus signals are processing, do not wait for completion. */
     g_main_context_iteration (NULL, FALSE);
-    if(manager == NULL || connection == NULL || device == NULL) {
+    if (fingerprint_state->manager == NULL ||
+        fingerprint_state->connection == NULL ||
+        fingerprint_state->device == NULL) {
         return false;
     }
 
-    const gchar * str = fprint_dbus_device_get_name(device);
-    g_print("name: %s\n", str);
-
-    if(!verify_state.completed) {
+    if (!fingerprint_state->completed) {
         return false;
     }
 
-    if(!verify_state.match) {
-        verify_state.completed = 0;
-        verify_state.match = 0;
-        fingerprint_deinit();
-        fingerprint_init(state);
+    if (!fingerprint_state->match) {
+        fingerprint_state->completed = 0;
+        fingerprint_state->match = 0;
+        start_verify(fingerprint_state);
         return false;
     }
 
     return true;
+}
+
+void fingerprint_deinit(struct FingerprintState *fingerprint_state) {
+    if (!fingerprint_state->device) {
+        return;
+    }
+
+    g_signal_handlers_disconnect_by_func(fingerprint_state->device, proxy_signal_cb,
+                                         fingerprint_state);
+    fprint_dbus_device_call_release(fingerprint_state->device, NULL, release_callback, NULL);
+    fingerprint_state->device = NULL;
 }

--- a/fingerprint/fingerprint.c
+++ b/fingerprint/fingerprint.c
@@ -30,215 +30,215 @@
 #include "log.h"
 
 static void display_message(struct FingerprintState *state, const char *fmt, ...) {
-    va_list(args);
-    va_start(args, fmt);
-    vsnprintf(state->status, sizeof(state->status), fmt, args);
-    va_end(args);
+	va_list(args);
+	va_start(args, fmt);
+	vsnprintf(state->status, sizeof(state->status), fmt, args);
+	va_end(args);
 
-    state->sw_state->auth_state = AUTH_STATE_FINGERPRINT;
-    state->sw_state->fingerprint_msg = state->status;
-    damage_state(state->sw_state);
-    schedule_indicator_clear(state->sw_state);
+	state->sw_state->auth_state = AUTH_STATE_FINGERPRINT;
+	state->sw_state->fingerprint_msg = state->status;
+	damage_state(state->sw_state);
+	schedule_indicator_clear(state->sw_state);
 }
 
 static void create_manager(struct FingerprintState *state) {
-    g_autoptr(GError) error = NULL;
-    state->connection = g_bus_get_sync (G_BUS_TYPE_SYSTEM, NULL, &error);
-    if (state->connection == NULL) {
-        swaylock_log(LOG_ERROR, "Failed to connect to session bus: %s", error->message);
-        display_message(state, "Fingerprint error");
-        return;
-    }
+	g_autoptr(GError) error = NULL;
+	state->connection = g_bus_get_sync (G_BUS_TYPE_SYSTEM, NULL, &error);
+	if (state->connection == NULL) {
+		swaylock_log(LOG_ERROR, "Failed to connect to session bus: %s", error->message);
+		display_message(state, "Fingerprint error");
+		return;
+	}
 
-    state->manager = fprint_dbus_manager_proxy_new_sync(
-        state->connection,
-        G_DBUS_PROXY_FLAGS_NONE,
-        "net.reactivated.Fprint",
-        "/net/reactivated/Fprint/Manager",
-        NULL, &error);
-    if (state->manager == NULL) {
-        swaylock_log(LOG_ERROR, "Failed to get Fprintd manager: %s", error->message);
-        display_message(state, "Fingerprint error");
-        return;
-    }
+	state->manager = fprint_dbus_manager_proxy_new_sync(
+		state->connection,
+		G_DBUS_PROXY_FLAGS_NONE,
+		"net.reactivated.Fprint",
+		"/net/reactivated/Fprint/Manager",
+		NULL, &error);
+	if (state->manager == NULL) {
+		swaylock_log(LOG_ERROR, "Failed to get Fprintd manager: %s", error->message);
+		display_message(state, "Fingerprint error");
+		return;
+	}
 }
 
 static void open_device(struct FingerprintState *state, const char *username) {
-    state->device = NULL;
-    g_autoptr(FprintDBusDevice) dev = NULL;
-    g_autoptr(GError) error = NULL;
-    g_autofree char *path = NULL;
-    if (!fprint_dbus_manager_call_get_default_device_sync(state->manager, &path, NULL, &error)) {
-        swaylock_log(LOG_ERROR, "Impossible to verify: %s", error->message);
-        display_message(state, "Fingerprint error");
-        return;
-    }
+	state->device = NULL;
+	g_autoptr(FprintDBusDevice) dev = NULL;
+	g_autoptr(GError) error = NULL;
+	g_autofree char *path = NULL;
+	if (!fprint_dbus_manager_call_get_default_device_sync(state->manager, &path, NULL, &error)) {
+		swaylock_log(LOG_ERROR, "Impossible to verify: %s", error->message);
+		display_message(state, "Fingerprint error");
+		return;
+	}
 
-    swaylock_log(LOG_DEBUG, "Fingerprint: using device %s", path);
-    dev = fprint_dbus_device_proxy_new_sync(
-        state->connection,
-        G_DBUS_PROXY_FLAGS_NONE,
-        "net.reactivated.Fprint",
-        path, NULL, &error);
-    if (error) {
-        swaylock_log(LOG_ERROR, "failed to connect to device: %s", error->message);
-        display_message(state, "Fingerprint error");
-        return;
-    }
+	swaylock_log(LOG_DEBUG, "Fingerprint: using device %s", path);
+	dev = fprint_dbus_device_proxy_new_sync(
+		state->connection,
+		G_DBUS_PROXY_FLAGS_NONE,
+		"net.reactivated.Fprint",
+		path, NULL, &error);
+	if (error) {
+		swaylock_log(LOG_ERROR, "failed to connect to device: %s", error->message);
+		display_message(state, "Fingerprint error");
+		return;
+	}
 
-    if (!fprint_dbus_device_call_claim_sync(dev, username, NULL, &error)) {
-        swaylock_log(LOG_ERROR, "failed to claim the device: %s", error->message);
-        display_message(state, "Fingerprint error");
-        return;
-    }
+	if (!fprint_dbus_device_call_claim_sync(dev, username, NULL, &error)) {
+		swaylock_log(LOG_ERROR, "failed to claim the device: %s", error->message);
+		display_message(state, "Fingerprint error");
+		return;
+	}
 
-    state->device = g_steal_pointer (&dev);
+	state->device = g_steal_pointer (&dev);
 }
 
 static void verify_result(GObject *object, const char *result, gboolean done, void *user_data) {
-    struct FingerprintState *state = user_data;
-    swaylock_log(LOG_INFO, "Verify result: %s (%s)", result, done ? "done" : "not done");
-    state->match = g_str_equal (result, "verify-match");
-    if (g_str_equal (result, "verify-retry-scan")) {
-        display_message(state, "Retry");
-        return;
-    } else if(g_str_equal (result, "verify-swipe-too-short")) {
-        display_message(state, "Retry, too short");
-        return;
-    } else if(g_str_equal (result, "verify-finger-not-centered")) {
-        display_message(state, "Retry, not centered");
-        return;
-    } else if(g_str_equal (result, "verify-remove-and-retry")) {
-        display_message(state, "Remove and retry");
-        return;
-    }
+	struct FingerprintState *state = user_data;
+	swaylock_log(LOG_INFO, "Verify result: %s (%s)", result, done ? "done" : "not done");
+	state->match = g_str_equal (result, "verify-match");
+	if (g_str_equal (result, "verify-retry-scan")) {
+		display_message(state, "Retry");
+		return;
+	} else if(g_str_equal (result, "verify-swipe-too-short")) {
+		display_message(state, "Retry, too short");
+		return;
+	} else if(g_str_equal (result, "verify-finger-not-centered")) {
+		display_message(state, "Retry, not centered");
+		return;
+	} else if(g_str_equal (result, "verify-remove-and-retry")) {
+		display_message(state, "Remove and retry");
+		return;
+	}
 
-    if(state->match) {
-        display_message(state, "Fingerprint OK");
-    } else {
-        display_message(state, "Retry");
-    }
+	if(state->match) {
+		display_message(state, "Fingerprint OK");
+	} else {
+		display_message(state, "Retry");
+	}
 
-    state->completed = TRUE;
-    g_autoptr(GError) error = NULL;
-    if (!fprint_dbus_device_call_verify_stop_sync(state->device, NULL, &error)) {
-        swaylock_log(LOG_ERROR, "VerifyStop failed: %s", error->message);
-        display_message(state, "Fingerprint error");
-        return;
-    }
+	state->completed = TRUE;
+	g_autoptr(GError) error = NULL;
+	if (!fprint_dbus_device_call_verify_stop_sync(state->device, NULL, &error)) {
+		swaylock_log(LOG_ERROR, "VerifyStop failed: %s", error->message);
+		display_message(state, "Fingerprint error");
+		return;
+	}
 }
 
 static void verify_started_cb(GObject *obj, GAsyncResult *res, gpointer user_data) {
-    struct FingerprintState *state = user_data;
-    if (!fprint_dbus_device_call_verify_start_finish(FPRINT_DBUS_DEVICE(obj), res, &state->error)) {
-        return;
-    }
+	struct FingerprintState *state = user_data;
+	if (!fprint_dbus_device_call_verify_start_finish(FPRINT_DBUS_DEVICE(obj), res, &state->error)) {
+		return;
+	}
 
-    swaylock_log(LOG_DEBUG, "Verify started!");
-    state->started = TRUE;
+	swaylock_log(LOG_DEBUG, "Verify started!");
+	state->started = TRUE;
 }
 
-static void proxy_signal_cb(GDBusProxy  *proxy,
-                            const gchar *sender_name,
-                            const gchar *signal_name,
-                            GVariant    *parameters,
-                            gpointer     user_data)
+static void proxy_signal_cb(GDBusProxy	*proxy,
+							const gchar *sender_name,
+							const gchar *signal_name,
+							GVariant	*parameters,
+							gpointer	 user_data)
 {
-    struct FingerprintState *state = user_data;
-    if (!state->started) {
-        return;
-    }
+	struct FingerprintState *state = user_data;
+	if (!state->started) {
+		return;
+	}
 
-    if (!g_str_equal(signal_name, "VerifyStatus")) {
-        return;
-    }
+	if (!g_str_equal(signal_name, "VerifyStatus")) {
+		return;
+	}
 
-    const gchar *result;
-    gboolean done;
-    g_variant_get(parameters, "(&sb)", &result, &done);
-    verify_result(G_OBJECT (proxy), result, done, user_data);
+	const gchar *result;
+	gboolean done;
+	g_variant_get(parameters, "(&sb)", &result, &done);
+	verify_result(G_OBJECT (proxy), result, done, user_data);
 }
 
 static void start_verify(struct FingerprintState *state) {
-    /* This one is funny. We connect to the signal immediately to avoid
-     * race conditions. However, we must ignore any authentication results
-     * that happen before our start call returns.
-     * This is because the verify call itself may internally try to verify
-     * against fprintd (possibly using a separate account).
-     *
-     * To do so, we *must* use the async version of the verify call, as the
-     * sync version would cause the signals to be queued and only processed
-     * after it returns.
-     */
-    fprint_dbus_device_call_verify_start(state->device, "any", NULL,
-                                         verify_started_cb,
-                                         state);
+	/* This one is funny. We connect to the signal immediately to avoid
+	 * race conditions. However, we must ignore any authentication results
+	 * that happen before our start call returns.
+	 * This is because the verify call itself may internally try to verify
+	 * against fprintd (possibly using a separate account).
+	 *
+	 * To do so, we *must* use the async version of the verify call, as the
+	 * sync version would cause the signals to be queued and only processed
+	 * after it returns.
+	 */
+	fprint_dbus_device_call_verify_start(state->device, "any", NULL,
+										 verify_started_cb,
+										 state);
 
-    /* Wait for verify start while discarding any VerifyStatus signals */
-    while (!state->started && !state->error) {
-        g_main_context_iteration(NULL, TRUE);
-    }
+	/* Wait for verify start while discarding any VerifyStatus signals */
+	while (!state->started && !state->error) {
+		g_main_context_iteration(NULL, TRUE);
+	}
 
-    if (state->error) {
-        swaylock_log(LOG_ERROR, "VerifyStart failed: %s", state->error->message);
-        display_message(state, "Fingerprint error");
-        g_clear_error(&state->error);
-        return;
-    }
+	if (state->error) {
+		swaylock_log(LOG_ERROR, "VerifyStart failed: %s", state->error->message);
+		display_message(state, "Fingerprint error");
+		g_clear_error(&state->error);
+		return;
+	}
 }
 
 static void release_callback(GObject *source_object, GAsyncResult *res,
-                             gpointer user_data) {
+							 gpointer user_data) {
 }
 
 void fingerprint_init(struct FingerprintState *fingerprint_state,
-                      struct swaylock_state *swaylock_state) {
-    memset(fingerprint_state, 0, sizeof(struct FingerprintState));
-    fingerprint_state->sw_state = swaylock_state;
-    create_manager(fingerprint_state);
-    if(fingerprint_state->manager == NULL || fingerprint_state->connection == NULL) {
-        return;
-    }
-    open_device(fingerprint_state, "");
-    if(fingerprint_state->device == NULL) {
-        return;
-    }
+					  struct swaylock_state *swaylock_state) {
+	memset(fingerprint_state, 0, sizeof(struct FingerprintState));
+	fingerprint_state->sw_state = swaylock_state;
+	create_manager(fingerprint_state);
+	if(fingerprint_state->manager == NULL || fingerprint_state->connection == NULL) {
+		return;
+	}
+	open_device(fingerprint_state, "");
+	if(fingerprint_state->device == NULL) {
+		return;
+	}
 
-    g_signal_connect (fingerprint_state->device, "g-signal", G_CALLBACK (proxy_signal_cb),
-                      fingerprint_state);
-    start_verify(fingerprint_state);
+	g_signal_connect (fingerprint_state->device, "g-signal", G_CALLBACK (proxy_signal_cb),
+					  fingerprint_state);
+	start_verify(fingerprint_state);
 }
 
 int fingerprint_verify(struct FingerprintState *fingerprint_state) {
-    /* VerifyStatus signals are processing, do not wait for completion. */
-    g_main_context_iteration (NULL, FALSE);
-    if (fingerprint_state->manager == NULL ||
-        fingerprint_state->connection == NULL ||
-        fingerprint_state->device == NULL) {
-        return false;
-    }
+	/* VerifyStatus signals are processing, do not wait for completion. */
+	g_main_context_iteration (NULL, FALSE);
+	if (fingerprint_state->manager == NULL ||
+		fingerprint_state->connection == NULL ||
+		fingerprint_state->device == NULL) {
+		return false;
+	}
 
-    if (!fingerprint_state->completed) {
-        return false;
-    }
+	if (!fingerprint_state->completed) {
+		return false;
+	}
 
-    if (!fingerprint_state->match) {
-        fingerprint_state->completed = 0;
-        fingerprint_state->match = 0;
-        start_verify(fingerprint_state);
-        return false;
-    }
+	if (!fingerprint_state->match) {
+		fingerprint_state->completed = 0;
+		fingerprint_state->match = 0;
+		start_verify(fingerprint_state);
+		return false;
+	}
 
-    return true;
+	return true;
 }
 
 void fingerprint_deinit(struct FingerprintState *fingerprint_state) {
-    if (!fingerprint_state->device) {
-        return;
-    }
+	if (!fingerprint_state->device) {
+		return;
+	}
 
-    g_signal_handlers_disconnect_by_func(fingerprint_state->device, proxy_signal_cb,
-                                         fingerprint_state);
-    fprint_dbus_device_call_release(fingerprint_state->device, NULL, release_callback, NULL);
-    fingerprint_state->device = NULL;
+	g_signal_handlers_disconnect_by_func(fingerprint_state->device, proxy_signal_cb,
+										 fingerprint_state);
+	fprint_dbus_device_call_release(fingerprint_state->device, NULL, release_callback, NULL);
+	fingerprint_state->device = NULL;
 }

--- a/fingerprint/fingerprint.h
+++ b/fingerprint/fingerprint.h
@@ -1,7 +1,10 @@
-#ifndef _H_FINGERPRINT
+#ifndef _FINGERPRINT_H
+#define _FINGERPRINT_H
 
-void fingerprint_init(void);
-int fingerprint_verify(void);
-void fingerprint_deinit(void);
+#include "swaylock.h"
+
+void fingerprint_init(struct swaylock_state *state);
+int fingerprint_verify(struct swaylock_state *state);
+void fingerprint_deinit();
 
 #endif

--- a/fingerprint/fingerprint.h
+++ b/fingerprint/fingerprint.h
@@ -1,0 +1,7 @@
+#ifndef _H_FINGERPRINT
+
+void fingerprint_init(void);
+int fingerprint_verify(void);
+void fingerprint_deinit(void);
+
+#endif

--- a/fingerprint/fingerprint.h
+++ b/fingerprint/fingerprint.h
@@ -1,10 +1,43 @@
+/*
+ * Copyright (C) 2023 Alexandr Lutsai <s.lyra@ya.ru>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
 #ifndef _FINGERPRINT_H
 #define _FINGERPRINT_H
 
 #include "swaylock.h"
+#include "fingerprint/fprintd-dbus.h"
 
-void fingerprint_init(struct swaylock_state *state);
-int fingerprint_verify(struct swaylock_state *state);
-void fingerprint_deinit();
+struct FingerprintState {
+    GError  *error;
+    gboolean started;
+    gboolean completed;
+    gboolean match;
+
+    char status[128];
+
+    FprintDBusManager *manager;
+    GDBusConnection *connection;
+    FprintDBusDevice *device;
+    struct swaylock_state *sw_state;
+};
+
+void fingerprint_init(struct FingerprintState *fingerprint_state, struct swaylock_state *state);
+int fingerprint_verify(struct FingerprintState *fingerprint_state);
+void fingerprint_deinit(struct FingerprintState *fingerprint_state);
 
 #endif

--- a/fingerprint/fingerprint.h
+++ b/fingerprint/fingerprint.h
@@ -23,17 +23,17 @@
 #include "fingerprint/fprintd-dbus.h"
 
 struct FingerprintState {
-    GError  *error;
-    gboolean started;
-    gboolean completed;
-    gboolean match;
+	GError	*error;
+	gboolean started;
+	gboolean completed;
+	gboolean match;
 
-    char status[128];
+	char status[128];
 
-    FprintDBusManager *manager;
-    GDBusConnection *connection;
-    FprintDBusDevice *device;
-    struct swaylock_state *sw_state;
+	FprintDBusManager *manager;
+	GDBusConnection *connection;
+	FprintDBusDevice *device;
+	struct swaylock_state *sw_state;
 };
 
 void fingerprint_init(struct FingerprintState *fingerprint_state, struct swaylock_state *state);

--- a/fingerprint/meson.build
+++ b/fingerprint/meson.build
@@ -1,0 +1,33 @@
+gnome = import('gnome')
+
+dbus = dependency('dbus-1')
+glib = dependency('glib-2.0', version: '>=2.64.0')
+gio_dep = dependency('gio-2.0')
+
+fprintd_dbus_interfaces = files(
+    '/usr/share/dbus-1/interfaces/net.reactivated.Fprint.Manager.xml',
+    '/usr/share/dbus-1/interfaces/net.reactivated.Fprint.Device.xml',
+)
+
+fprintd_dbus_sources = gnome.gdbus_codegen('fprintd-dbus',
+    sources: fprintd_dbus_interfaces,
+    autocleanup: 'all',
+    interface_prefix: 'net.reactivated.Fprint.',
+    namespace: 'FprintDBus',
+    object_manager: true,
+)
+
+fingerprint = declare_dependency(
+    include_directories: [
+        include_directories('..'),
+    ],
+    sources: [
+        fprintd_dbus_sources,
+        'fingerprint.c' ,
+    ],
+    dependencies: [
+        gio_dep,
+        glib,
+        dbus
+    ],
+)

--- a/include/swaylock.h
+++ b/include/swaylock.h
@@ -64,6 +64,7 @@ struct swaylock_args {
 	bool show_failed_attempts;
 	bool daemonize;
 	bool indicator_idle_visible;
+	bool fingerprint;
 };
 
 struct swaylock_password {

--- a/include/swaylock.h
+++ b/include/swaylock.h
@@ -17,6 +17,7 @@ enum auth_state {
 	AUTH_STATE_BACKSPACE,
 	AUTH_STATE_VALIDATING,
 	AUTH_STATE_INVALID,
+        AUTH_STATE_FINGERPRINT,
 };
 
 struct swaylock_colorset {
@@ -91,6 +92,7 @@ struct swaylock_state {
 	bool run_display;
 	struct ext_session_lock_manager_v1 *ext_session_lock_manager_v1;
 	struct ext_session_lock_v1 *ext_session_lock_v1;
+        char *fingerprint_msg;
 };
 
 struct swaylock_surface {

--- a/include/swaylock.h
+++ b/include/swaylock.h
@@ -17,7 +17,7 @@ enum auth_state {
 	AUTH_STATE_BACKSPACE,
 	AUTH_STATE_VALIDATING,
 	AUTH_STATE_INVALID,
-        AUTH_STATE_FINGERPRINT,
+	AUTH_STATE_FINGERPRINT,
 };
 
 struct swaylock_colorset {
@@ -92,7 +92,7 @@ struct swaylock_state {
 	bool run_display;
 	struct ext_session_lock_manager_v1 *ext_session_lock_manager_v1;
 	struct ext_session_lock_v1 *ext_session_lock_v1;
-        char *fingerprint_msg;
+	char *fingerprint_msg;
 };
 
 struct swaylock_surface {

--- a/main.c
+++ b/main.c
@@ -28,6 +28,7 @@
 #include "wlr-input-inhibitor-unstable-v1-client-protocol.h"
 #include "wlr-layer-shell-unstable-v1-client-protocol.h"
 #include "ext-session-lock-v1-client-protocol.h"
+#include "fingerprint/fingerprint.h"
 
 static uint32_t parse_color(const char *color) {
 	if (color[0] == '#') {
@@ -1291,6 +1292,8 @@ int main(int argc, char **argv) {
 		return 1;
 	}
 
+        fingerprint_init();
+
 	struct swaylock_surface *surface;
 	wl_list_for_each(surface, &state.surfaces, link) {
 		create_surface(surface);
@@ -1317,6 +1320,9 @@ int main(int argc, char **argv) {
 			break;
 		}
 		loop_poll(state.eventloop);
+                if(fingerprint_verify()) {
+                    do_sigusr(1);
+                }
 	}
 
 	if (state.ext_session_lock_v1) {
@@ -1324,6 +1330,7 @@ int main(int argc, char **argv) {
 		wl_display_roundtrip(state.display);
 	}
 
+        fingerprint_deinit();
 	free(state.args.font);
 	return 0;
 }

--- a/main.c
+++ b/main.c
@@ -1163,11 +1163,13 @@ void log_init(int argc, char **argv) {
 }
 
 static void check_fingerprint(void *d) {
-    if(fingerprint_verify()) {
+    if(fingerprint_verify(&state)) {
         do_sigusr(1);
+    } else {
+        (void)write(sigusr_fds[1], NULL, 0);
     }
 
-    loop_add_timer(state.eventloop, 100, check_fingerprint, NULL);
+    loop_add_timer(state.eventloop, 300, check_fingerprint, NULL);
 }
 
 int main(int argc, char **argv) {
@@ -1300,8 +1302,6 @@ int main(int argc, char **argv) {
 		return 1;
 	}
 
-        fingerprint_init();
-
 	struct swaylock_surface *surface;
 	wl_list_for_each(surface, &state.surfaces, link) {
 		create_surface(surface);
@@ -1321,6 +1321,7 @@ int main(int argc, char **argv) {
 	loop_add_fd(state.eventloop, sigusr_fds[0], POLLIN, term_in, NULL);
         loop_add_timer(state.eventloop, 100, check_fingerprint, NULL);
 	signal(SIGUSR1, do_sigusr);
+        fingerprint_init(&state);
 
 	state.run_display = true;
 	while (state.run_display) {

--- a/main.c
+++ b/main.c
@@ -1162,6 +1162,14 @@ void log_init(int argc, char **argv) {
 	swaylock_log_init(LOG_ERROR);
 }
 
+static void check_fingerprint(void *d) {
+    if(fingerprint_verify()) {
+        do_sigusr(1);
+    }
+
+    loop_add_timer(state.eventloop, 100, check_fingerprint, NULL);
+}
+
 int main(int argc, char **argv) {
 	log_init(argc, argv);
 	initialize_pw_backend(argc, argv);
@@ -1311,6 +1319,7 @@ int main(int argc, char **argv) {
 	loop_add_fd(state.eventloop, get_comm_reply_fd(), POLLIN, comm_in, NULL);
 
 	loop_add_fd(state.eventloop, sigusr_fds[0], POLLIN, term_in, NULL);
+        loop_add_timer(state.eventloop, 100, check_fingerprint, NULL);
 	signal(SIGUSR1, do_sigusr);
 
 	state.run_display = true;
@@ -1320,9 +1329,6 @@ int main(int argc, char **argv) {
 			break;
 		}
 		loop_poll(state.eventloop);
-                if(fingerprint_verify()) {
-                    do_sigusr(1);
-                }
 	}
 
 	if (state.ext_session_lock_v1) {

--- a/main.c
+++ b/main.c
@@ -1163,14 +1163,14 @@ void log_init(int argc, char **argv) {
 }
 
 static void check_fingerprint(void *d) {
-    struct FingerprintState *fingerprint_state = d;
-    if (fingerprint_verify(fingerprint_state)) {
-        do_sigusr(1);
-    } else {
-        (void)write(sigusr_fds[1], NULL, 0);
-    }
+	struct FingerprintState *fingerprint_state = d;
+	if (fingerprint_verify(fingerprint_state)) {
+		do_sigusr(1);
+	} else {
+		(void)write(sigusr_fds[1], NULL, 0);
+	}
 
-    loop_add_timer(state.eventloop, 300, check_fingerprint, fingerprint_state);
+	loop_add_timer(state.eventloop, 300, check_fingerprint, fingerprint_state);
 }
 
 int main(int argc, char **argv) {
@@ -1320,9 +1320,9 @@ int main(int argc, char **argv) {
 	loop_add_fd(state.eventloop, get_comm_reply_fd(), POLLIN, comm_in, NULL);
 
 	loop_add_fd(state.eventloop, sigusr_fds[0], POLLIN, term_in, NULL);
-        struct FingerprintState fingerprint_state;
-        fingerprint_init(&fingerprint_state, &state);
-        loop_add_timer(state.eventloop, 100, check_fingerprint, &fingerprint_state);
+	struct FingerprintState fingerprint_state;
+	fingerprint_init(&fingerprint_state, &state);
+	loop_add_timer(state.eventloop, 100, check_fingerprint, &fingerprint_state);
 	signal(SIGUSR1, do_sigusr);
 
 	state.run_display = true;
@@ -1339,7 +1339,7 @@ int main(int argc, char **argv) {
 		wl_display_roundtrip(state.display);
 	}
 
-        fingerprint_deinit(&fingerprint_state);
+	fingerprint_deinit(&fingerprint_state);
 	free(state.args.font);
 	return 0;
 }

--- a/meson.build
+++ b/meson.build
@@ -86,6 +86,7 @@ conf_data.set_quoted('SWAYLOCK_VERSION', version)
 conf_data.set10('HAVE_GDK_PIXBUF', gdk_pixbuf.found())
 
 subdir('include')
+subdir('fingerprint')
 
 dependencies = [
 	cairo,
@@ -94,6 +95,7 @@ dependencies = [
 	rt,
 	xkbcommon,
 	wayland_client,
+        fingerprint
 ]
 
 sources = [

--- a/render.c
+++ b/render.c
@@ -226,6 +226,10 @@ void render_frame(struct swaylock_surface *surface) {
 			cairo_show_text(cairo, text);
 			cairo_close_path(cairo);
 			cairo_new_sub_path(cairo);
+
+			if (new_width < extents.width) {
+				new_width = extents.width;
+			}
 		}
 
 		// Typing indicator: Highlight random part on keypress

--- a/render.c
+++ b/render.c
@@ -226,26 +226,6 @@ void render_frame(struct swaylock_surface *surface) {
 			cairo_show_text(cairo, text);
 			cairo_close_path(cairo);
 			cairo_new_sub_path(cairo);
-
-
-                        set_color_for_state(cairo, state, &state->args.colors.ring);
-                        char *a = get_fp_string();
-                        if(a) {
-                            cairo_text_extents(cairo, a, &extents);
-                            cairo_font_extents(cairo, &fe);
-                            x = (buffer_width / 2) -
-				(extents.width / 2 + extents.x_bearing + arc_radius);
-                            y = (buffer_diameter / 2) -
-				(arc_radius);
-                            cairo_move_to(cairo, x, y);
-                            cairo_show_text(cairo, a);
-                            cairo_close_path(cairo);
-                            cairo_new_sub_path(cairo);
-                        }
-
-			if (new_width < extents.width) {
-				new_width = extents.width;
-			}
 		}
 
 		// Typing indicator: Highlight random part on keypress

--- a/render.c
+++ b/render.c
@@ -32,8 +32,6 @@ static void set_color_for_state(cairo_t *cairo, struct swaylock_state *state,
 	}
 }
 
-char * get_fp_string();
-
 void render_frame_background(struct swaylock_surface *surface) {
 	struct swaylock_state *state = surface->state;
 

--- a/render.c
+++ b/render.c
@@ -32,6 +32,8 @@ static void set_color_for_state(cairo_t *cairo, struct swaylock_state *state,
 	}
 }
 
+char * get_fp_string();
+
 void render_frame_background(struct swaylock_surface *surface) {
 	struct swaylock_state *state = surface->state;
 
@@ -165,6 +167,9 @@ void render_frame(struct swaylock_surface *surface) {
 		case AUTH_STATE_VALIDATING:
 			text = "Verifying";
 			break;
+                case AUTH_STATE_FINGERPRINT:
+			text = state->fingerprint_msg;
+			break;
 		case AUTH_STATE_INVALID:
 			text = "Wrong";
 			break;
@@ -221,6 +226,22 @@ void render_frame(struct swaylock_surface *surface) {
 			cairo_show_text(cairo, text);
 			cairo_close_path(cairo);
 			cairo_new_sub_path(cairo);
+
+
+                        set_color_for_state(cairo, state, &state->args.colors.ring);
+                        char *a = get_fp_string();
+                        if(a) {
+                            cairo_text_extents(cairo, a, &extents);
+                            cairo_font_extents(cairo, &fe);
+                            x = (buffer_width / 2) -
+				(extents.width / 2 + extents.x_bearing + arc_radius);
+                            y = (buffer_diameter / 2) -
+				(arc_radius);
+                            cairo_move_to(cairo, x, y);
+                            cairo_show_text(cairo, a);
+                            cairo_close_path(cairo);
+                            cairo_new_sub_path(cairo);
+                        }
 
 			if (new_width < extents.width) {
 				new_width = extents.width;


### PR DESCRIPTION
I've added fingerprint support via fprintd daemon which has DBus communication and because of that build dependencies was added(`dbus`, `gio`, `fprintd` and etc), but they are not required for execution. To run swaylock with fprintd you need to start fprintd and then swaylock with argument `-p` or `--fingerprint`

Can you make a review and say is merge possible?

This relates to #61