### PR TITLE
Stop pooling background surface buffers

### DIFF
--- a/include/pool-buffer.h
+++ b/include/pool-buffer.h
@@ -15,8 +15,10 @@ struct pool_buffer {
 	bool busy;
 };
 
+struct pool_buffer *create_buffer(struct wl_shm *shm, struct pool_buffer *buf,
+	int32_t width, int32_t height, uint32_t format);
 struct pool_buffer *get_next_buffer(struct wl_shm *shm,
-		struct pool_buffer pool[static 2], uint32_t width, uint32_t height);
+	struct pool_buffer pool[static 2], uint32_t width, uint32_t height);
 void destroy_buffer(struct pool_buffer *buffer);
 
 #endif

--- a/include/swaylock.h
+++ b/include/swaylock.h
@@ -98,11 +98,10 @@ struct swaylock_surface {
 	struct swaylock_state *state;
 	struct wl_output *output;
 	uint32_t output_global_name;
-	struct wl_surface *surface;
-	struct wl_surface *child; // surface made into subsurface
+	struct wl_surface *surface; // surface for background
+	struct wl_surface *child; // indicator surface made into subsurface
 	struct wl_subsurface *subsurface;
 	struct ext_session_lock_surface_v1 *ext_session_lock_surface_v1;
-	struct pool_buffer buffers[2];
 	struct pool_buffer indicator_buffers[2];
 	bool frame_pending, dirty;
 	uint32_t width, height;
@@ -110,6 +109,8 @@ struct swaylock_surface {
 	enum wl_output_subpixel subpixel;
 	char *output_name;
 	struct wl_list link;
+	// Dimensions of last wl_buffer committed to background surface
+	int last_buffer_width, last_buffer_height;
 };
 
 // There is exactly one swaylock_image for each -i argument

--- a/main.c
+++ b/main.c
@@ -100,8 +100,6 @@ static void destroy_surface(struct swaylock_surface *surface) {
 	if (surface->surface != NULL) {
 		wl_surface_destroy(surface->surface);
 	}
-	destroy_buffer(&surface->buffers[0]);
-	destroy_buffer(&surface->buffers[1]);
 	destroy_buffer(&surface->indicator_buffers[0]);
 	destroy_buffer(&surface->indicator_buffers[1]);
 	wl_output_destroy(surface->output);

--- a/pool-buffer.c
+++ b/pool-buffer.c
@@ -46,7 +46,7 @@ static const struct wl_buffer_listener buffer_listener = {
 	.release = buffer_release
 };
 
-static struct pool_buffer *create_buffer(struct wl_shm *shm,
+struct pool_buffer *create_buffer(struct wl_shm *shm,
 		struct pool_buffer *buf, int32_t width, int32_t height,
 		uint32_t format) {
 	uint32_t stride = width * 4;


### PR DESCRIPTION
Quoting the commit message:
> The wl_buffers for the background surface only need to be updated when the output dimensions change. Using the fixed pool of two buffers to cache these buffers does not help, since if a new buffer is needed, it will have a different size than whatever buffers were cached. Furthermore, because the pool has fixed size, it is possible to run out of buffers if configure events arrive faster than pool buffers  are marked not busy,, which can lead to protocol errors when the background surface is committed after acknowledging a new size, but without attaching a buffer that matches that size.

Without this change, one way to make Swaylock run out of buffers is to run it inside a nested instance of Sway, configured to draw a large image as the background, and then rapidly resize the nested instance until Swaylock receives several configure events in a single `wl_display_dispatch()` call.

This fixes https://github.com/swaywm/swaylock/issues/180 and _might_ help with https://github.com/swaywm/swaylock/issues/282.

The new buffer allocation strategy for the background is closer to what swaybg does.