### PR TITLE
Synchronize highlight position between outputs

### DIFF
--- a/include/swaylock.h
+++ b/include/swaylock.h
@@ -87,6 +87,7 @@ struct swaylock_state {
 	cairo_surface_t *test_surface;
 	cairo_t *test_cairo; // used to estimate font/text sizes
 	enum auth_state auth_state;
+	uint32_t highlight_start; // position of highlight; 2048 = 1 full turn
 	int failed_attempts;
 	bool run_display, locked;
 	struct ext_session_lock_manager_v1 *ext_session_lock_manager_v1;

--- a/password.c
+++ b/password.c
@@ -93,6 +93,12 @@ static void submit_password(struct swaylock_state *state) {
 	damage_state(state);
 }
 
+static void update_highlight(struct swaylock_state *state) {
+	// Advance a random amount between 1/4 and 3/4 of a full turn
+	state->highlight_start =
+		(state->highlight_start + (rand() % 1024) + 512) % 2048;
+}
+
 void swaylock_handle_key(struct swaylock_state *state,
 		xkb_keysym_t keysym, uint32_t codepoint) {
 	// Ignore input events if validating
@@ -109,6 +115,7 @@ void swaylock_handle_key(struct swaylock_state *state,
 	case XKB_KEY_BackSpace:
 		if (backspace(&state->password)) {
 			state->auth_state = AUTH_STATE_BACKSPACE;
+			update_highlight(state);
 		} else {
 			state->auth_state = AUTH_STATE_CLEAR;
 		}
@@ -160,6 +167,7 @@ void swaylock_handle_key(struct swaylock_state *state,
 		if (codepoint) {
 			append_ch(&state->password, codepoint);
 			state->auth_state = AUTH_STATE_INPUT;
+			update_highlight(state);
 			damage_state(state);
 			schedule_indicator_clear(state);
 			schedule_password_clear(state);

--- a/render.c
+++ b/render.c
@@ -271,9 +271,7 @@ void render_frame(struct swaylock_surface *surface) {
 		// Typing indicator: Highlight random part on keypress
 		if (state->auth_state == AUTH_STATE_INPUT
 				|| state->auth_state == AUTH_STATE_BACKSPACE) {
-			static double highlight_start = 0;
-			highlight_start +=
-				(rand() % (int)(M_PI * 100)) / 100.0 + M_PI * 0.5;
+			double highlight_start = state->highlight_start * (M_PI / 1024.0);
 			cairo_arc(cairo, buffer_width / 2, buffer_diameter / 2,
 					arc_radius, highlight_start,
 					highlight_start + TYPE_INDICATOR_RANGE);


### PR DESCRIPTION
This change makes Swaylock look slightly nicer, by ensuring that highlight positions are updated once per key stroke, and not once per time a frame is drawn -- which could make highlight positions change differently depending on the number of active monitors.

For example, with two outputs, _before_ this change, the highlight position would change independently for each output, and often by small amounts due to it being updated twice / rotated by two approximate half turns:
[bad.webm](https://user-images.githubusercontent.com/7674289/229323465-13a21727-e985-4bdc-a820-de43bad7402b.webm)
And _after_ this change:
[good.webm](https://user-images.githubusercontent.com/7674289/229323476-8a80889d-478c-4d2b-a077-933ac9a713d8.webm)