### PR TITLE
Separate password validation and input state machines

### DIFF
--- a/include/swaylock.h
+++ b/include/swaylock.h
@@ -8,14 +8,20 @@
 #include "pool-buffer.h"
 #include "seat.h"
 
+// Indicator state: status of authentication attempt
 enum auth_state {
-	AUTH_STATE_IDLE,
-	AUTH_STATE_CLEAR,
-	AUTH_STATE_INPUT,
-	AUTH_STATE_INPUT_NOP,
-	AUTH_STATE_BACKSPACE,
-	AUTH_STATE_VALIDATING,
-	AUTH_STATE_INVALID,
+	AUTH_STATE_IDLE, // nothing happening
+	AUTH_STATE_VALIDATING, // currently validating password
+	AUTH_STATE_INVALID, // displaying message: password was wrong
+};
+
+// Indicator state: status of password buffer / typing letters
+enum input_state {
+	INPUT_STATE_IDLE, // nothing happening; other states decay to this after time
+	INPUT_STATE_CLEAR, // displaying message: password buffer was cleared
+	INPUT_STATE_LETTER, // pressed a key that input a letter
+	INPUT_STATE_BACKSPACE, // pressed backspace and removed a letter
+	INPUT_STATE_NEUTRAL, // pressed a key (like Ctrl) that did nothing
 };
 
 struct swaylock_colorset {
@@ -73,7 +79,8 @@ struct swaylock_password {
 
 struct swaylock_state {
 	struct loop *eventloop;
-	struct loop_timer *clear_indicator_timer; // clears the indicator
+	struct loop_timer *input_idle_timer; // timer to reset input state to IDLE
+	struct loop_timer *auth_idle_timer; // timer to stop displaying AUTH_STATE_INVALID
 	struct loop_timer *clear_password_timer;  // clears the password buffer
 	struct wl_display *display;
 	struct wl_compositor *compositor;
@@ -86,7 +93,8 @@ struct swaylock_state {
 	struct swaylock_xkb xkb;
 	cairo_surface_t *test_surface;
 	cairo_t *test_cairo; // used to estimate font/text sizes
-	enum auth_state auth_state;
+	enum auth_state auth_state; // state of the authentication attempt
+	enum input_state input_state; // state of the password buffer and key inputs
 	uint32_t highlight_start; // position of highlight; 2048 = 1 full turn
 	int failed_attempts;
 	bool run_display, locked;
@@ -129,7 +137,7 @@ void render_frame(struct swaylock_surface *surface);
 void damage_surface(struct swaylock_surface *surface);
 void damage_state(struct swaylock_state *state);
 void clear_password_buffer(struct swaylock_password *pw);
-void schedule_indicator_clear(struct swaylock_state *state);
+void schedule_auth_idle(struct swaylock_state *state);
 
 void initialize_pw_backend(int argc, char **argv);
 void run_pw_backend_child(void);

--- a/main.c
+++ b/main.c
@@ -1072,7 +1072,7 @@ static void comm_in(int fd, short mask, void *data) {
 		state.run_display = false;
 	} else {
 		state.auth_state = AUTH_STATE_INVALID;
-		schedule_indicator_clear(&state);
+		schedule_auth_idle(&state);
 		++state.failed_attempts;
 		damage_state(&state);
 	}


### PR DESCRIPTION
This commit mostly decouples the parts of the indicator state related to authentication messages from those related to keyboard input. This makes it possible to type input while a previous password is verifying, without hiding the `verifying/wrong` message as soon as a key is pressed.


Note: i3lock currently has the ring highlight indicators vanish about 0.25 seconds after a key press; since Swaylock currently keeps them around until transitioning to the idle state, I have not tried to match the i3lock behavior more closely here.