### PR TITLE
Show cleared state when backspacing last character

### DIFF
--- a/password.c
+++ b/password.c
@@ -146,7 +146,7 @@ void swaylock_handle_key(struct swaylock_state *state,
 			state->input_state = INPUT_STATE_CLEAR;
 			cancel_password_clear(state);
 		} else {
-			if (backspace(&state->password)) {
+			if (backspace(&state->password) && state->password.len != 0) {
 				state->input_state = INPUT_STATE_BACKSPACE;
 				schedule_password_clear(state);
 				update_highlight(state);


### PR DESCRIPTION
Typing `A<backspace>` did not result in the cleared state even though the buffer was empty. One had to press backspace one more time to reach it.

I also tried always returning `pw->len != 0` from `backspace()` after the buffer has been modified, which fixes this as well.
But I decided against that, because then the meaning of the return value is unintuitive.