### PR TITLE
Fix Wayland object leaks when outputs are destroyed

### DIFF
--- a/main.c
+++ b/main.c
@@ -97,12 +97,18 @@ static void destroy_surface(struct swaylock_surface *surface) {
 	if (surface->ext_session_lock_surface_v1 != NULL) {
 		ext_session_lock_surface_v1_destroy(surface->ext_session_lock_surface_v1);
 	}
+	if (surface->subsurface) {
+		wl_subsurface_destroy(surface->subsurface);
+	}
+	if (surface->child) {
+		wl_surface_destroy(surface->child);
+	}
 	if (surface->surface != NULL) {
 		wl_surface_destroy(surface->surface);
 	}
 	destroy_buffer(&surface->indicator_buffers[0]);
 	destroy_buffer(&surface->indicator_buffers[1]);
-	wl_output_destroy(surface->output);
+	wl_output_release(surface->output);
 	free(surface);
 }
 


### PR DESCRIPTION
This fixes a Wayland object leak when an output global is removed. One way to reproduce this (and verify that the commit entirely fixes the issue) is to run a nested instance of sway with two outputs (`WLR_WL_OUTPUTS=2 sway`), repeatedly turn one of the two outputs on/off ...
```bash
for i in {1..100}
do
        swaymsg output WL-2 disable
        sleep 0.5
        swaymsg output WL-2 enable
        sleep 0.5;
done
```
... and while this is happening, run `WAYLAND_DEBUG=client swaylock`. Without this PR, the values of new object IDs will increase by 3 for each disable/enable cycle; with it, the maximum ID value of created objects should be less than 30 or so.
