### PR TITLE
Don't send READY=1 for readiness notifications

### DIFF
--- a/main.c
+++ b/main.c
@@ -1251,10 +1251,7 @@ int main(int argc, char **argv) {
 	}
 
 	if (state.args.ready_fd >= 0) {
-		// s6 wants a newline and ignores any text before that, systemd wants
-		// READY=1, so use the least common denominator
-		const char ready_str[] = "READY=1\n";
-		if (write(state.args.ready_fd, ready_str, strlen(ready_str)) != strlen(ready_str)) {
+		if (write(state.args.ready_fd, "\n", 1) != 1) {
 			swaylock_log(LOG_ERROR, "Failed to send readiness notification");
 			return 2;
 		}


### PR DESCRIPTION
Just send a singular newline like s6 expects.

systemd doesn't support spawning a process with an FD to send readiness notifications to, instead it provides a socket name. IOW, this cannot be used directly with systemd after all.

Closes: https://github.com/swaywm/swaylock/issues/312