### PR TITLE
Implement handling SIGUSR2 to record external failed authentication attempts

### DIFF
--- a/comm.c
+++ b/comm.c
@@ -1,3 +1,5 @@
+#define _POSIX_C_SOURCE 200809L
+#include <signal.h>
 #include <stdbool.h>
 #include <stdlib.h>
 #include <sys/types.h>
@@ -62,6 +64,12 @@ bool spawn_comm_child(void) {
 	} else if (child == 0) {
 		close(comm[0][1]);
 		close(comm[1][0]);
+		struct sigaction sa;
+		sa.sa_handler = SIG_IGN;
+		sigemptyset(&sa.sa_mask);
+		sa.sa_flags = 0;
+		sigaction(SIGUSR1, &sa, NULL);
+		sigaction(SIGUSR2, &sa, NULL);
 		run_pw_backend_child();
 	}
 	close(comm[0][0]);

--- a/main.c
+++ b/main.c
@@ -341,7 +341,7 @@ static const struct wl_registry_listener registry_listener = {
 static int sigusr_fds[2] = {-1, -1};
 
 void do_sigusr(int sig) {
-	(void)write(sigusr_fds[1], "1", 1);
+	(void)write(sigusr_fds[1], &sig, sizeof(sig));
 }
 
 static cairo_surface_t *select_image(struct swaylock_state *state,
@@ -1085,7 +1085,21 @@ static void comm_in(int fd, short mask, void *data) {
 }
 
 static void term_in(int fd, short mask, void *data) {
-	state.run_display = false;
+	int sig = -1;
+	if (read(sigusr_fds[0], &sig, sizeof(sig)) != sizeof(sig)) {
+		swaylock_log_errno(LOG_ERROR, "Failed to read signum");
+		return;
+	}
+	if (sig == SIGUSR1) {
+		// External unlock succeeded
+		state.run_display = false;
+	}
+	else {
+		state.auth_state = AUTH_STATE_INVALID;
+		schedule_auth_idle(&state);
+		++state.failed_attempts;
+		damage_state(&state);
+	}
 }
 
 // Check for --debug 'early' we also apply the correct loglevel
@@ -1279,6 +1293,7 @@ int main(int argc, char **argv) {
 	sigemptyset(&sa.sa_mask);
 	sa.sa_flags = SA_RESTART;
 	sigaction(SIGUSR1, &sa, NULL);
+	sigaction(SIGUSR2, &sa, NULL);
 
 	state.run_display = true;
 	while (state.run_display) {

--- a/swaylock.1.scd
+++ b/swaylock.1.scd
@@ -194,6 +194,9 @@ Locks your Wayland session.
 *SIGUSR1*
 	Unlock the screen and exit.
 
+*SIGUSR2*
+	Increases failed-attempts counter e.g. from external fingerprint-verification.
+
 # AUTHORS
 
 Maintained by Drew DeVault <sir@cmpwn.com>, who is assisted by other open


### PR DESCRIPTION
This adds support for indicating external authentication failures using `SIGUSR2`, in addition to the existing support for external authentication successes using `SIGUSR1`

Since `SIGUSR*` defaults to termination, we ignore them in the forked pw backend children (which worked already because `SIGUSR1` ends up in termination anyway, but we do not want that to happen for `SIGUSR2`)

This is intended to be usable with an external program that can handle fprintd communication as an alternative to #283

Supersedes and closes #311