### PR TITLE
Add support for OpenBSD

### DIFF
--- a/bsdauth.c
+++ b/bsdauth.c
@@ -1,0 +1,51 @@
+#include <pwd.h>
+#include <stdlib.h>
+#include <stdbool.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <login_cap.h>
+#include <bsd_auth.h>
+#include <grp.h>
+
+#include "comm.h"
+#include "log.h"
+#include "password-buffer.h"
+#include "swaylock.h"
+
+void initialize_pw_backend(int argc, char **argv) {
+	if (!spawn_comm_child()) {
+		exit(EXIT_FAILURE);
+	}
+}
+void run_pw_backend_child(void) {
+	struct passwd *pwent = getpwuid(getuid());
+	if (!pwent) {
+		swaylock_log_errno(LOG_ERROR, "failed to getpwuid");
+		exit(EXIT_FAILURE);
+	}
+	struct group *authg = getgrnam("auth");
+	if (!authg || !authg->gr_name || !*authg->gr_name) {
+		exit(EXIT_FAILURE);
+	}
+	/* we need setgid(auth) to use auth_userokay() */
+	if (setgid(authg->gr_gid)) {
+		exit(EXIT_FAILURE);
+	}
+	while (1) {
+		char *buf;
+		ssize_t size = read_comm_request(&buf);
+		if (size < 0) {
+			exit(EXIT_FAILURE);
+		} else if (size == 0) {
+			break;
+		}
+		bool success = auth_userokay((char *)pwent->pw_name, NULL, "swaylock", buf);
+		if (!write_comm_reply(success)) {
+			exit(EXIT_FAILURE);
+		}
+
+		sleep(2);
+	}
+
+	exit(EXIT_SUCCESS);
+}

--- a/main.c
+++ b/main.c
@@ -1002,6 +1002,7 @@ static bool file_exists(const char *path) {
 }
 
 static char *get_config_path(void) {
+#if HAVE_WORDEXP
 	static const char *config_paths[] = {
 		"$HOME/.swaylock/config",
 		"$XDG_CONFIG_HOME/swaylock/config",
@@ -1025,7 +1026,50 @@ static char *get_config_path(void) {
 			free(path);
 		}
 	}
+#else
+	char *home = getenv("HOME");
+	char *path;
+	int n, len;
+	if (home) {
+		len = strlen(home) + strlen("/.swaylock/config") + 1;
+		path = malloc(len);
+		if (path == NULL)
+			return NULL;
+		n = snprintf(path, len, "%s/.swaylock/config", home);
+		if (n < len && file_exists(path))
+			return path;
+		free(path);
+		char *config_home = getenv("XDG_CONFIG_HOME");
+		if (!config_home || config_home[0] == '\0') {
+			len = strlen(home) + strlen("/.config/swaylock/config") + 1;
+			path = malloc(len);
+			if (path == NULL)
+				return NULL;
+			n = snprintf(path, len, "%s/.config/swaylock/config", home);
+			if (n < len && file_exists(path))
+				return path;
+			free(path);
+		} else {
+			len = strlen(config_home) + strlen("/swaylock/config") + 1;
+			path = malloc(len);
+			if (path == NULL)
+				return NULL;
+			n = snprintf(path, len, "%s/swaylock/config", config_home);
+			if (n < len && file_exists(path))
+				return path;
+			free(path);
+		}
+	}
+	len = strlen(SYSCONFDIR "/swaylock/config") + 1;
+	path = malloc(len);
+	if (path == NULL)
+		return NULL;
+	n = snprintf(path, len, "%s/swaylock/config", SYSCONFDIR);
+	if (n < len && file_exists(path))
+		return path;
+	free(path);
 
+#endif
 	return NULL;
 }
 

--- a/main.c
+++ b/main.c
@@ -15,7 +15,10 @@
 #include <time.h>
 #include <unistd.h>
 #include <wayland-client.h>
+#include "config.h"
+#if HAVE_WORDEXP
 #include <wordexp.h>
+#endif
 #include "background-image.h"
 #include "cairo.h"
 #include "comm.h"
@@ -358,6 +361,7 @@ static cairo_surface_t *select_image(struct swaylock_state *state,
 	return default_image;
 }
 
+#if HAVE_WORDEXP
 static char *join_args(char **argv, int argc) {
 	assert(argc > 0);
 	int len = 0, i;
@@ -374,6 +378,7 @@ static char *join_args(char **argv, int argc) {
 	res[len - 1] = '\0';
 	return res;
 }
+#endif
 
 static void load_image(char *arg, struct swaylock_state *state) {
 	// [[<output>]:]<path>
@@ -411,18 +416,22 @@ static void load_image(char *arg, struct swaylock_state *state) {
 	// The shell will not expand ~ to the value of $HOME when an output name is
 	// given. Also, any image paths given in the config file need to have shell
 	// expansions performed
+#if HAVE_WORDEXP
 	wordexp_t p;
+#endif
 	while (strstr(image->path, "  ")) {
 		image->path = realloc(image->path, strlen(image->path) + 2);
 		char *ptr = strstr(image->path, "  ") + 1;
 		memmove(ptr + 1, ptr, strlen(ptr) + 1);
 		*ptr = '\\';
 	}
+#if HAVE_WORDEXP
 	if (wordexp(image->path, &p, 0) == 0) {
 		free(image->path);
 		image->path = join_args(p.we_wordv, p.we_wordc);
 		wordfree(&p);
 	}
+#endif
 
 	// Load the actual image
 	image->cairo_surface = load_background_image(image->path);

--- a/meson.build
+++ b/meson.build
@@ -128,10 +128,12 @@ executable('swaylock',
 	install: true
 )
 
-install_data(
-	'pam/swaylock',
-	install_dir: get_option('sysconfdir') / 'pam.d'
-)
+if libpam.found()
+	install_data(
+		'pam/swaylock',
+		install_dir: get_option('sysconfdir') / 'pam.d'
+	)
+endif
 
 if scdoc.found()
 	mandir = get_option('mandir')

--- a/meson.build
+++ b/meson.build
@@ -24,6 +24,7 @@ add_project_arguments(
 cc = meson.get_compiler('c')
 
 is_freebsd = host_machine.system().startswith('freebsd')
+is_openbsd = host_machine.system().startswith('openbsd')
 
 if is_freebsd
 	add_project_arguments('-D_C11_SOURCE', language: 'c')
@@ -36,9 +37,9 @@ xkbcommon = dependency('xkbcommon')
 cairo = dependency('cairo')
 gdk_pixbuf = dependency('gdk-pixbuf-2.0', required: get_option('gdk-pixbuf'))
 libpam = cc.find_library('pam', required: get_option('pam'))
-crypt = cc.find_library('crypt', required: not libpam.found())
+crypt = cc.find_library('crypt', required: not libpam.found() and not is_openbsd)
 math = cc.find_library('m')
-rt = cc.find_library('rt')
+rt = cc.find_library('rt', required: not is_openbsd)
 
 git = find_program('git', required: false)
 scdoc = find_program('scdoc', required: get_option('man-pages'))
@@ -89,7 +90,6 @@ dependencies = [
 	cairo,
 	gdk_pixbuf,
 	math,
-	rt,
 	xkbcommon,
 	wayland_client,
 ]
@@ -111,12 +111,12 @@ sources = [
 
 if libpam.found()
 	sources += ['pam.c']
-	dependencies += [libpam]
+	dependencies += [libpam, rt]
 else
 	warning('The swaylock binary must be setuid when compiled without libpam')
 	warning('You must do this manually post-install: chmod a+s /path/to/swaylock')
 	sources += ['shadow.c']
-	dependencies += [crypt]
+	dependencies += [crypt, rt]
 endif
 
 swaylock_inc = include_directories('include')

--- a/meson.build
+++ b/meson.build
@@ -112,6 +112,10 @@ sources = [
 if libpam.found()
 	sources += ['pam.c']
 	dependencies += [libpam, rt]
+elif is_openbsd
+	warning('The swaylock binary must be setgid when compiled with bsd auth')
+	warning('You must do this manually post-install: chgrp auth /path/to/swaylock ; chmod g+s /path/to/swaylock')
+	sources += ['bsdauth.c']
 else
 	warning('The swaylock binary must be setuid when compiled without libpam')
 	warning('You must do this manually post-install: chmod a+s /path/to/swaylock')

--- a/meson.build
+++ b/meson.build
@@ -81,6 +81,7 @@ conf_data = configuration_data()
 conf_data.set_quoted('SYSCONFDIR', get_option('prefix') / get_option('sysconfdir'))
 conf_data.set_quoted('SWAYLOCK_VERSION', version)
 conf_data.set10('HAVE_GDK_PIXBUF', gdk_pixbuf.found())
+conf_data.set10('HAVE_WORDEXP', cc.check_header('wordexp.h'))
 
 subdir('include')
 

--- a/render.c
+++ b/render.c
@@ -6,7 +6,9 @@
 #include "swaylock.h"
 #include "log.h"
 
+#ifndef M_PI
 #define M_PI 3.14159265358979323846
+#endif
 const float TYPE_INDICATOR_RANGE = M_PI / 3.0f;
 const float TYPE_INDICATOR_BORDER_THICKNESS = M_PI / 128.0f;
 


### PR DESCRIPTION
OpenBSD has initial/wip wayland support, so add support for building/using swaylock on OpenBSD. It uses http://man.openbsd.org/auth_userokay for user authentication so integrates well with the various login methods.

There's no `wordexp()` on OpenBSD:
- it had security issues in the past (cf https://nvd.nist.gov/vuln/detail/CVE-2022-3008 &https://www.cvedetails.com/cve/CVE-2021-35942/) 
- and it is generally considered a too dangerous/large hammer to solve small issues
so i've written a small function to lookup for configuration files in the same paths, and i've tested that it was functionally equivalent.

been able to use swaylock with `image=/usr/local/share/backgrounds/xfce/xfce-blue.jpg` in `~/.config/swaylock/config swaylock` and it does what's expected.

Feedback welcome !