### PR TITLE
Fix retry behaviour in while loop with mlock()

### DIFF
--- a/password-buffer.c
+++ b/password-buffer.c
@@ -38,7 +38,6 @@ static bool password_buffer_lock(char *addr, size_t size) {
 			swaylock_log_errno(LOG_ERROR, "Unable to mlock() password memory.");
 			return false;
 		}
-		return false;
 	}
 
 	return true;


### PR DESCRIPTION
If mlock() fails with errno EAGAIN, it should be retried up to five times, which is tracked in the retries variable. However, the `return false` statement after the switch case makes the function return false after the first failed mlock() call.

Remove this statement to actually retry up to five times.