### PR TITLE
Link to manpage

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ swaylock is a screen locking utility for Wayland compositors. It is compatible
 with any Wayland compositor which implements the ext-session-lock-v1 Wayland
 protocol.
 
-See the man page, `swaylock(1)`, for instructions on using swaylock.
+See the man page, [swaylock(1)](swaylock.1.scd), for instructions on using swaylock.
 
 ## Release Signatures
 


### PR DESCRIPTION
The README for `swayidle` has a convenient link to the manpage, following suit here.