### PR TITLE
Updated: Fix output-specific images when output reappears

### DIFF
--- a/include/swaylock.h
+++ b/include/swaylock.h
@@ -112,6 +112,7 @@ struct swaylock_surface {
 	struct wl_subsurface *subsurface;
 	struct ext_session_lock_surface_v1 *ext_session_lock_surface_v1;
 	struct pool_buffer indicator_buffers[2];
+	bool created;
 	bool frame_pending, dirty;
 	uint32_t width, height;
 	int32_t scale;


### PR DESCRIPTION
Since #155 hasn't been touched in quite a while, I figured I'd take a shot at dragging it across the finish line. The patch has been rebased and modified to use wl_output instead of xdg_output. The remaining feedback from the previous pull request has also been addressed.