### PR TITLE
Trim trailing whitespace in config file

### DIFF
--- a/main.c
+++ b/main.c
@@ -1020,6 +1020,19 @@ static char *get_config_path(void) {
 	return NULL;
 }
 
+static void trim_end(char *str) {
+	if (strlen(str) == 0) {
+		return;
+	}
+
+	char* end = str + strlen(str) - 1;
+	while (end > str && isspace((unsigned char)*end)) {
+		end--;
+	}
+
+	*(end + 1) = '\0';
+}
+
 static int load_config(char *path, struct swaylock_state *state,
 		enum line_mode *line_mode) {
 	FILE *config = fopen(path, "r");
@@ -1042,6 +1055,8 @@ static int load_config(char *path, struct swaylock_state *state,
 		if (!*line || line[0] == '#') {
 			continue;
 		}
+
+		trim_end(line);
 
 		swaylock_log(LOG_DEBUG, "Config Line #%d: %s", line_number, line);
 		char *flag = malloc(nread + 3);


### PR DESCRIPTION
I noticed one of the options in my config file wasn't working. It turned out this is because it had a space at the end of the line

I thought it could be nice to trim the whitespace at the end of the line so we don't leave people head scratching like I was! If preferred, we could spit out a warning instead of trimming. Then that would make it easier to find out why a configuration isn't working

I don't often write C, so feel free to suggest any changes, I'll be happy to implement them!

Also, I'm new to this repo, so if there's already something like `trim_end` I should be using instead, or if I should move the function to another file, please let me know 🙂