### PR TITLE
Init eventloop directly after wl_connect

### DIFF
--- a/main.c
+++ b/main.c
@@ -1205,6 +1205,7 @@ int main(int argc, char **argv) {
 				"WAYLAND_DISPLAY environment variable.");
 		return EXIT_FAILURE;
 	}
+	state.eventloop = loop_create();
 
 	struct wl_registry *registry = wl_display_get_registry(state.display);
 	wl_registry_add_listener(registry, &registry_listener, &state);
@@ -1269,7 +1270,6 @@ int main(int argc, char **argv) {
 		daemonize();
 	}
 
-	state.eventloop = loop_create();
 	loop_add_fd(state.eventloop, wl_display_get_fd(state.display), POLLIN,
 			display_in, NULL);
 


### PR DESCRIPTION
I observed some segfaults and was finally able to catch them in the debugger. Turns out some key events are
getting dispatched before the `eventloop` is initialized, which will try to insert some timers in the non existing
loop. So this PR moves initialization of the eventloop to directly after initializing the connection.

(Note: There is a `loop_destroy` function defined, but it seems to be unused)

```
#1  0x000055bd6d561cf2 in loop_add_timer
    (loop=0x0, ms=<optimized out>, callback=callback@entry=0x55bd6d564540 <keyboard_repeat>, data=data@entry=0x55bd6ec1fdd0)
```

<details>
<summary><b>Backtrace</b></summary>

```
#0  0x00007fe8f4d393a9 in wl_list_insert (list=list@entry=0x20, elm=elm@entry=0x55bd6ec10508) at ../src/wayland-util.c:48
#1  0x000055bd6d561cf2 in loop_add_timer
    (loop=0x0, ms=<optimized out>, callback=callback@entry=0x55bd6d564540 <keyboard_repeat>, data=data@entry=0x55bd6ec1fdd0)
    at ../loop.c:172
#2  0x000055bd6d566452 in keyboard_key
    (data=0x55bd6ec1fdd0, wl_keyboard=<optimized out>, serial=<optimized out>, time=<optimized out>, key=<optimized out>, _key_state=1)
    at ../seat.c:79
#3  0x00007fe8f42dc056 in ffi_call_unix64 () at ../src/x86/unix64.S:104
#4  0x00007fe8f42d85ef in ffi_call_int
    (cif=cif@entry=0x7ffe468be3e0, fn=<optimized out>, rvalue=<optimized out>, avalue=<optimized out>, closure=closure@entry=0x0)
    at ../src/x86/ffi64.c:673
#5  0x00007fe8f42db3fe in ffi_call
    (cif=cif@entry=0x7ffe468be3e0, fn=<optimized out>, rvalue=rvalue@entry=0x0, avalue=avalue@entry=0x7ffe468be4b0)
    at ../src/x86/ffi64.c:710
#6  0x00007fe8f4d38f0e in wl_closure_invoke (closure=closure@entry=0x55bd6ec4cdb0, target=<optimized out>,
    target@entry=0x55bd6ec20440, opcode=opcode@entry=3, data=<optimized out>, flags=1) at ../src/connection.c:1025
#7  0x00007fe8f4d39793 in dispatch_event (display=display@entry=0x55bd6ec19bc0, queue=0x55bd6ec19cb0) at ../src/wayland-client.c:1631
#8  0x00007fe8f4d39a3c in dispatch_queue (queue=0x55bd6ec19cb0, display=0x55bd6ec19bc0) at ../src/wayland-client.c:1777
#9  wl_display_dispatch_queue_pending (display=0x55bd6ec19bc0, queue=0x55bd6ec19cb0) at ../src/wayland-client.c:2019
#10 0x00007fe8f4d3b664 in wl_display_dispatch_queue (queue=<optimized out>, display=<optimized out>) at ../src/wayland-client.c:1995
#11 0x00007fe8f4d3b680 in wl_display_dispatch (display=<optimized out>) at ../src/wayland-client.c:2062
#12 0x000055bd6d56087f in main (argc=<optimized out>, argv=<optimized out>) at ../main.c:1301
```
</details>

<details>
<summary><b>State</b></summary>

```
{
  eventloop = 0x0,
  clear_indicator_timer = 0x0,
  clear_password_timer = 0x0,
  display = 0x55bd6ec19bc0,
  compositor = 0x55bd6ec20dc0,
  subcompositor = 0x55bd6ec20f90,
  layer_shell = 0x55bd6ec21120,
  input_inhibit_manager = 0x0,
  shm = 0x55bd6ec21440,
  surfaces = {
    prev = 0x55bd6ec20708,
    next = 0x55bd6ec20908
  },
  images = {
    prev = 0x55bd6d56da78 <state+88>,
    next = 0x55bd6d56da78 <state+88>
  },
  args = {
    colors = {
      background = 4294967295,
      bs_highlight = 3677552895,
      key_highlight = 869990655,
      caps_lock_bs_highlight = 3677552895,
      caps_lock_key_highlight = 869990655,
      separator = 255,
      layout_background = 192,
      layout_border = 0,
      layout_text = 4294967295,
      inside = {
        input = 192,
        cleared = 3852748224,
        caps_lock = 192,
        verifying = 7536576,
        wrong = 4194304192
      },
      line = {
        input = 255,
        cleared = 255,
        caps_lock = 255,
        verifying = 255,
        wrong = 255
      },
      ring = {
        input = 863830271,
        cleared = 3852748287,
        caps_lock = 3852748287,
        verifying = 855703551,
        wrong = 2100494591
      },
      text = {
        input = 3852748287,
        cleared = 255,
        caps_lock = 3852748287,
        verifying = 255,
        wrong = 255
      }
    },
    mode = BACKGROUND_MODE_FILL,
    font = 0x55bd6ec12600 "sans-serif",
    font_size = 0,
    radius = 50,
    thickness = 10,
    indicator_x_position = 0,
    indicator_y_position = 0,
    override_indicator_x_position = false,
    override_indicator_y_position = false,
    ignore_empty = false,
    show_indicator = true,
    show_caps_lock_text = true,
    show_caps_lock_indicator = false,
    show_keyboard_layout = false,
    hide_keyboard_layout = false,
    show_failed_attempts = false,
    daemonize = false,
    indicator_idle_visible = false
  },
  password = {
    len = 0,
    buffer_len = 1024,
    buffer = 0x55bd6ec1a000 ""
  },
  xkb = {
    caps_lock = false,
    control = false,
    state = 0x55bd6ec83030,
    context = 0x55bd6ec1a410,
    keymap = 0x55bd6ec22610
  },
  test_surface = 0x55bd6ec1f6f0,
  test_cairo = 0x55bd6ec21650,
  auth_state = AUTH_STATE_VALIDATING,
  failed_attempts = 0,
  run_display = false,
  locked = false,
  ext_session_lock_manager_v1 = 0x55bd6ec212b0,
  ext_session_lock_v1 = 0x55bd6ec209c0
}
```
</details>