### PR TITLE
lock-cmd: Configurable accessory process

### DIFF
--- a/include/swaylock.h
+++ b/include/swaylock.h
@@ -69,6 +69,7 @@ struct swaylock_args {
 	bool daemonize;
 	int ready_fd;
 	bool indicator_idle_visible;
+	char *lock_cmd;
 };
 
 struct swaylock_password {

--- a/swaylock.1.scd
+++ b/swaylock.1.scd
@@ -42,6 +42,14 @@ Locks your Wayland session.
 	At this point, the compositor guarantees that no security sensitive content
 	is visible on-screen.
 
+*--lock-cmd* <cmdline>
+	Command-line to execute while swaylock is locked, and terminated by
+	SIGTERM once swaylock terminates.
+
+	This can be useful to run a dedicated swayidle instance during the
+	screenlock to manage screen timeout at different intervals than the
+	active session.
+
 *-h, --help*
 	Show help message and quit.
 


### PR DESCRIPTION
The normal swayidle + swaylock setup uses a series of global timeouts to control outputs and locking at once, meaning that timeout behavior for a locked session and an active session are the same.

A user may instead want much shorter, or different, timeouts for the locked session. For example, an active session may have a 300 second timeout to start swaylock, while swaylock has a 30 second timeout to disable outputs.

To easily manage this, `lock-cmd` allows swaylock to start a process which will be killed with SIGTERM once the session is unlocked, tying the lifetime to the lockscreen itself.

Name open to bikeshedding.