### PR TITLE
Add `--default-text`

### DIFF
--- a/completions/bash/swaylock
+++ b/completions/bash/swaylock
@@ -34,6 +34,7 @@ _swaylock()
     --config
     --daemonize
     --debug
+    --default-text
     --disable-caps-lock-text
     --font
     --font-size

--- a/completions/fish/swaylock.fish
+++ b/completions/fish/swaylock.fish
@@ -7,6 +7,7 @@ complete -c swaylock -l color                  -s c --description "Turn the scre
 complete -c swaylock -l config                 -s C --description "Path to the config file."
 complete -c swaylock -l daemonize              -s f --description "Detach from the controlling terminal after locking."
 complete -c swaylock -l debug                  -s d --description "Enable debugging output."
+complete -c swaylock -l default-text                --description "Show text when no other (Caps Lock, attempt count, etc.) is shown."
 complete -c swaylock -l disable-caps-lock-text -s L --description "Disable the Caps Lock text."
 complete -c swaylock -l font                        --description "Sets the font of the text."
 complete -c swaylock -l font-size                   --description "Sets a fixed font size for the indicator text."

--- a/completions/zsh/_swaylock
+++ b/completions/zsh/_swaylock
@@ -11,6 +11,7 @@ _arguments -s \
 	'(--config -C)'{--config,-C}'[Path to the config file]:filename:_files' \
 	'(--daemonize -f)'{--daemonize,-f}'[Detach from the controlling terminal after locking]' \
 	'(--debug -d)'{--debug,-d}'[Enable debugging output]' \
+	'(--default-text)'--default-text'[Show text when no other (Caps Lock, attempt count, etc.) is shown]:text:' \
 	'(--disable-caps-lock-text -L)'{--disable-caps-lock-text,-L}'[Disable the Caps Lock text]' \
 	'(--font)'--font'[Sets the font of the text]:font:' \
 	'(--font-size)'--font-size'[Sets a fixed font size for the indicator text]' \

--- a/include/swaylock.h
+++ b/include/swaylock.h
@@ -66,6 +66,7 @@ struct swaylock_args {
 	bool show_keyboard_layout;
 	bool hide_keyboard_layout;
 	bool show_failed_attempts;
+	char *default_text;
 	bool daemonize;
 	int ready_fd;
 	bool indicator_idle_visible;

--- a/main.c
+++ b/main.c
@@ -484,7 +484,8 @@ enum line_mode {
 static int parse_options(int argc, char **argv, struct swaylock_state *state,
 		enum line_mode *line_mode, char **config_path) {
 	enum long_option_codes {
-		LO_BS_HL_COLOR = 256,
+		LO_DEFAULT_TEXT = 256,
+		LO_BS_HL_COLOR,
 		LO_CAPS_LOCK_BS_HL_COLOR,
 		LO_CAPS_LOCK_KEY_HL_COLOR,
 		LO_FONT,
@@ -541,6 +542,7 @@ static int parse_options(int argc, char **argv, struct swaylock_state *state,
 		{"hide-keyboard-layout", no_argument, NULL, 'K'},
 		{"show-failed-attempts", no_argument, NULL, 'F'},
 		{"version", no_argument, NULL, 'v'},
+		{"default-text", required_argument, NULL, LO_DEFAULT_TEXT},
 		{"bs-hl-color", required_argument, NULL, LO_BS_HL_COLOR},
 		{"caps-lock-bs-hl-color", required_argument, NULL, LO_CAPS_LOCK_BS_HL_COLOR},
 		{"caps-lock-key-hl-color", required_argument, NULL, LO_CAPS_LOCK_KEY_HL_COLOR},
@@ -616,6 +618,8 @@ static int parse_options(int argc, char **argv, struct swaylock_state *state,
 			"Disable the unlock indicator.\n"
 		"  -v, --version                    "
 			"Show the version number and quit.\n"
+		"  --default-text <text>            "
+			"Show text when no other (Caps Lock, attempt count, etc.) is shown.\n"
 		"  --bs-hl-color <color>            "
 			"Sets the color of backspace highlight segments.\n"
 		"  --caps-lock-bs-hl-color <color>  "
@@ -800,6 +804,12 @@ static int parse_options(int argc, char **argv, struct swaylock_state *state,
 		case 'v':
 			fprintf(stdout, "swaylock version " SWAYLOCK_VERSION "\n");
 			exit(EXIT_SUCCESS);
+			break;
+		case LO_DEFAULT_TEXT:
+			if (state) {
+				free(state->args.default_text);
+				state->args.default_text = strdup(optarg);
+			}
 			break;
 		case LO_BS_HL_COLOR:
 			if (state) {
@@ -1138,6 +1148,7 @@ int main(int argc, char **argv) {
 		.show_keyboard_layout = false,
 		.hide_keyboard_layout = false,
 		.show_failed_attempts = false,
+		.default_text = NULL,
 		.indicator_idle_visible = false,
 		.ready_fd = -1,
 	};

--- a/render.c
+++ b/render.c
@@ -151,6 +151,8 @@ void render_frame(struct swaylock_surface *surface) {
 				layout_text = xkb_keymap_layout_get_name(state->xkb.keymap, curr_layout);
 			}
 		}
+	} else if (state->args.default_text) {
+		text = state->args.default_text;
 	}
 
 	// Compute the size of the buffer needed
@@ -245,27 +247,9 @@ void render_frame(struct swaylock_surface *surface) {
 		set_color_for_state(cairo, state, &state->args.colors.ring);
 		cairo_stroke(cairo);
 
-		// Draw a message
-		configure_font_drawing(cairo, state, surface->subpixel, arc_radius);
-		set_color_for_state(cairo, state, &state->args.colors.text);
+	}
 
-		if (text) {
-			cairo_text_extents_t extents;
-			cairo_font_extents_t fe;
-			double x, y;
-			cairo_text_extents(cairo, text, &extents);
-			cairo_font_extents(cairo, &fe);
-			x = (buffer_width / 2) -
-				(extents.width / 2 + extents.x_bearing);
-			y = (buffer_diameter / 2) +
-				(fe.height / 2 - fe.descent);
-
-			cairo_move_to(cairo, x, y);
-			cairo_show_text(cairo, text);
-			cairo_close_path(cairo);
-			cairo_new_sub_path(cairo);
-		}
-
+	if (draw_indicator) {
 		// Typing indicator: Highlight random part on keypress
 		if (state->input_state == INPUT_STATE_LETTER ||
 				state->input_state == INPUT_STATE_BACKSPACE) {
@@ -311,37 +295,58 @@ void render_frame(struct swaylock_surface *surface) {
 		cairo_arc(cairo, buffer_width / 2, buffer_diameter / 2,
 				arc_radius + arc_thickness / 2, 0, 2 * M_PI);
 		cairo_stroke(cairo);
+	}
 
-		// display layout text separately
-		if (layout_text) {
-			cairo_text_extents_t extents;
-			cairo_font_extents_t fe;
-			double x, y;
-			double box_padding = 4.0 * surface->scale;
-			cairo_text_extents(cairo, layout_text, &extents);
-			cairo_font_extents(cairo, &fe);
-			// upper left coordinates for box
-			x = (buffer_width / 2) - (extents.width / 2) - box_padding;
-			y = buffer_diameter;
+	// Draw a message
+	configure_font_drawing(cairo, state, surface->subpixel, arc_radius);
+	set_color_for_state(cairo, state, &state->args.colors.text);
 
-			// background box
-			cairo_rectangle(cairo, x, y,
-				extents.width + 2.0 * box_padding,
-				fe.height + 2.0 * box_padding);
-			cairo_set_source_u32(cairo, state->args.colors.layout_background);
-			cairo_fill_preserve(cairo);
-			// border
-			cairo_set_source_u32(cairo, state->args.colors.layout_border);
-			cairo_stroke(cairo);
+	if (text) {
+		cairo_text_extents_t extents;
+		cairo_font_extents_t fe;
+		double x, y;
+		cairo_text_extents(cairo, text, &extents);
+		cairo_font_extents(cairo, &fe);
+		x = (buffer_width / 2) -
+			(extents.width / 2 + extents.x_bearing);
+		y = (buffer_diameter / 2) +
+			(fe.height / 2 - fe.descent);
 
-			// take font extents and padding into account
-			cairo_move_to(cairo,
-				x - extents.x_bearing + box_padding,
-				y + (fe.height - fe.descent) + box_padding);
-			cairo_set_source_u32(cairo, state->args.colors.layout_text);
-			cairo_show_text(cairo, layout_text);
-			cairo_new_sub_path(cairo);
-		}
+		cairo_move_to(cairo, x, y);
+		cairo_show_text(cairo, text);
+		cairo_close_path(cairo);
+		cairo_new_sub_path(cairo);
+	}
+
+	// display layout text separately
+	if (layout_text) {
+		cairo_text_extents_t extents;
+		cairo_font_extents_t fe;
+		double x, y;
+		double box_padding = 4.0 * surface->scale;
+		cairo_text_extents(cairo, layout_text, &extents);
+		cairo_font_extents(cairo, &fe);
+		// upper left coordinates for box
+		x = (buffer_width / 2) - (extents.width / 2) - box_padding;
+		y = buffer_diameter;
+
+		// background box
+		cairo_rectangle(cairo, x, y,
+			extents.width + 2.0 * box_padding,
+			fe.height + 2.0 * box_padding);
+		cairo_set_source_u32(cairo, state->args.colors.layout_background);
+		cairo_fill_preserve(cairo);
+		// border
+		cairo_set_source_u32(cairo, state->args.colors.layout_border);
+		cairo_stroke(cairo);
+
+		// take font extents and padding into account
+		cairo_move_to(cairo,
+			x - extents.x_bearing + box_padding,
+			y + (fe.height - fe.descent) + box_padding);
+		cairo_set_source_u32(cairo, state->args.colors.layout_text);
+		cairo_show_text(cairo, layout_text);
+		cairo_new_sub_path(cairo);
 	}
 
 	// Send Wayland requests

--- a/swaylock.1.scd
+++ b/swaylock.1.scd
@@ -84,6 +84,9 @@ Locks your Wayland session.
 	sets the background of the image to the given color. Defaults to white
 	(FFFFFF).
 
+*--default-text* <text>
+	Show text when no other (Caps Lock, attempt count, etc.) is shown.
+
 *--bs-hl-color* <rrggbb[aa]>
 	Sets the color of backspace highlight segments.
 


### PR DESCRIPTION
I set swaylock's background color to #000000 by default, which worked great until I got an OLED monitor. Now I can't tell if the screen is off (due to swayidle) or on (displaying the black background). The new `--default-text` option shows a message (for me, simply "Locked") in the center of the screen whenever no other messages (e.g. "Caps Lock", the number of failed attempts, etc.) are shown. I know I could do this with a pre-baked background image but this is slightly nicer.