### PR TITLE
Allow 3- and 4-digit hex colors

### DIFF
--- a/main.c
+++ b/main.c
@@ -32,17 +32,33 @@ static uint32_t parse_color(const char *color) {
 		++color;
 	}
 
-	int len = strlen(color);
-	if (len != 6 && len != 8) {
-		swaylock_log(LOG_DEBUG, "Invalid color %s, defaulting to 0xFFFFFFFF",
-				color);
-		return 0xFFFFFFFF;
+	size_t len = strlen(color);
+	if (len == 3 || len == 4) {
+		errno = 0;
+		uint32_t res = (uint32_t)strtoul(color, NULL, 16);
+		if (errno == 0) {
+			if (len == 3) {
+					res = res << 4 | 0xF;
+			}
+			uint32_t r = ((res >> 12) & 0xF) * 0x11000000;
+			uint32_t g = ((res >> 8) & 0xF)  * 0x00110000;
+			uint32_t b = ((res >> 4) & 0xF)  * 0x00001100;
+			uint32_t a = (res & 0xF)         * 0x00000011;
+			return r | g | b | a;
+		}
+	} else if (len == 6 || len == 8) {
+		errno = 0;
+		uint32_t res = (uint32_t)strtoul(color, NULL, 16);
+		if (errno == 0) {
+			if (len == 6) {
+				res = res << 8 | 0xFF;
+			}
+			return res;
+		}
 	}
-	uint32_t res = (uint32_t)strtoul(color, NULL, 16);
-	if (strlen(color) == 6) {
-		res = (res << 8) | 0xFF;
-	}
-	return res;
+
+	swaylock_log(LOG_DEBUG, "Invalid color %s, defaulting to 0xFFFFFFFF", color);
+	return 0xFFFFFFFF;
 }
 
 int lenient_strcmp(char *a, char *b) {


### PR DESCRIPTION
These are common enough (especially on the web) that a new user might try to use a 3-digit hex color such as `#f00` (or one with transparency such as `#f008`). We might as well make this work and save a few seconds of confusion/RTFM.

Also, print the "Invalid color" message if the color string is of an allowed length, but not parseable as a hex color (example: `#bruh`). No reason to be as [lenient as HTML](https://stackoverflow.com/questions/8318911/why-does-html-think-chucknorris-is-a-color).