### PR TITLE
Correct for image orientation when loading image (fix from swaybg)

### DIFF
--- a/background-image.c
+++ b/background-image.c
@@ -31,8 +31,12 @@ cairo_surface_t *load_background_image(const char *path) {
 				err->message);
 		return NULL;
 	}
-	image = gdk_cairo_image_surface_create_from_pixbuf(pixbuf);
+	// Correct for embedded image orientation; typical images are not
+	// rotated and will be handled efficiently
+	GdkPixbuf *oriented = gdk_pixbuf_apply_embedded_orientation(pixbuf);
 	g_object_unref(pixbuf);
+	image = gdk_cairo_image_surface_create_from_pixbuf(oriented);
+	g_object_unref(oriented);
 #else
 	image = cairo_image_surface_create_from_png(path);
 #endif // HAVE_GDK_PIXBUF


### PR DESCRIPTION
JPEG and other image formats may include an EXIF orientation tag which indicates in what orientation (rotation and mirroring) the image should be displayed. libgdk-pixbuf does not correct for this when loading an image, but provides a function to apply the transform after the fact, which this commit uses.

Fix pulled from swaybg - see https://github.com/swaywm/swaybg/pull/68 for the original patch

Closes: #357 