### PR TITLE
Support output IDs

### DIFF
--- a/include/swaylock.h
+++ b/include/swaylock.h
@@ -118,6 +118,7 @@ struct swaylock_surface {
 	int32_t scale;
 	enum wl_output_subpixel subpixel;
 	char *output_name;
+	char *output_description;
 	struct wl_list link;
 	// Dimensions of last wl_buffer committed to background surface
 	int last_buffer_width, last_buffer_height;
@@ -127,6 +128,7 @@ struct swaylock_surface {
 struct swaylock_image {
 	char *path;
 	char *output_name;
+	char *output_id;
 	cairo_surface_t *cairo_surface;
 	struct wl_list link;
 };

--- a/main.c
+++ b/main.c
@@ -259,7 +259,19 @@ static void handle_wl_output_name(void *data, struct wl_output *output,
 
 static void handle_wl_output_description(void *data, struct wl_output *output,
 		const char *description) {
-	// Who cares
+	swaylock_log(LOG_DEBUG, "handle_wl_output_description %s ", description);
+
+	struct swaylock_surface *surface = data;
+
+	// The output description will be in the format "<make> <model> <serial> (<output>)" like Dell Inc. DELL U3223QE G76Y9P3 (DP-5)
+	// so cutting it at the last space
+	char *separator = strrchr(description, ' ');
+	if (separator) {
+		*separator = '\0';
+		surface->output_description  = strdup(description);
+	}
+
+	swaylock_log(LOG_DEBUG, "set _%s_", surface->output_description );
 }
 
 struct wl_output_listener _wl_output_listener = {
@@ -349,7 +361,7 @@ static cairo_surface_t *select_image(struct swaylock_state *state,
 	struct swaylock_image *image;
 	cairo_surface_t *default_image = NULL;
 	wl_list_for_each(image, &state->images, link) {
-		if (lenient_strcmp(image->output_name, surface->output_name) == 0) {
+		if (lenient_strcmp(image->output_name, surface->output_name) == 0 || lenient_strcmp(image->output_name, surface->output_description) == 0) {
 			return image->cairo_surface;
 		} else if (!image->output_name) {
 			default_image = image->cairo_surface;


### PR DESCRIPTION
I need to support targeting the output with the output identifier (`Dell Inc. DELL U3223QE GB6Y9P3`) rather than just the output name (eg. `DP-6`) because the output name might change every time I replug my monitors and I want my internal OLED display to have no image while my external monitors should have a nice image.

Example:
`swaylock -f -c 000000 --image "Dell Inc. DELL U3223QE GB6Y9P3":~/Pictures/1.jpg -d`

The wl_output_description returns the full model, make and output name so I am trimming the output name from the output description to match kanshi and sway output id matching.