### PR TITLE
Allow indicator offsets to start from bottom and right

### DIFF
--- a/include/swaylock.h
+++ b/include/swaylock.h
@@ -55,8 +55,8 @@ struct swaylock_args {
 	uint32_t font_size;
 	uint32_t radius;
 	uint32_t thickness;
-	uint32_t indicator_x_position;
-	uint32_t indicator_y_position;
+	int32_t indicator_x_position;
+	int32_t indicator_y_position;
 	bool override_indicator_x_position;
 	bool override_indicator_y_position;
 	bool ignore_empty;

--- a/render.c
+++ b/render.c
@@ -226,16 +226,26 @@ static bool render_frame(struct swaylock_surface *surface) {
 
 	// Center the indicator unless overridden by the user
 	if (state->args.override_indicator_x_position) {
-		subsurf_xpos = state->args.indicator_x_position -
-			buffer_width / (2 * surface->scale) + 2 / surface->scale;
+		if (state->args.indicator_x_position < 0) {
+			subsurf_xpos =  surface->width + state->args.indicator_x_position -
+				buffer_width / (2 * surface->scale) + 2 / surface->scale;
+		} else {
+			subsurf_xpos = state->args.indicator_x_position -
+				buffer_width / (2 * surface->scale) + 2 / surface->scale;
+		}
 	} else {
 		subsurf_xpos = surface->width / 2 -
 			buffer_width / (2 * surface->scale) + 2 / surface->scale;
 	}
 
 	if (state->args.override_indicator_y_position) {
-		subsurf_ypos = state->args.indicator_y_position -
-			(state->args.radius + state->args.thickness);
+		if (state->args.indicator_y_position < 0) {
+			subsurf_ypos = surface->height + state->args.indicator_y_position -
+				(state->args.radius + state->args.thickness);
+		} else {
+			subsurf_ypos = state->args.indicator_y_position -
+				(state->args.radius + state->args.thickness);
+		}
 	} else {
 		subsurf_ypos = surface->height / 2 -
 			(state->args.radius + state->args.thickness);


### PR DESCRIPTION
Hi,

I like to put the indicator in the lower-left corner of my screen. I do this my hard-coding my [current device screen size](https://github.com/mrnossiom/dotfiles/blob/8d20107c77b0452e42d4f3bd08225df686aab83a/nixos/modules/info.nix#L8-L24) in my config and then performing [offset calculations](https://github.com/mrnossiom/dotfiles/blob/8d20107c77b0452e42d4f3bd08225df686aab83a/home-manager/modules/vm/default.nix#L47-L48). This is ok as a solution but doesn't work when you connect external monitors which don't have the same sizes.

I propose to change `indicator-{x,y}-position` from a `uint` to a `int` whose negative values gets interpreted as an offset from the right/bottom.

I don't think this change is breaking.