### PR TITLE
Only submit password if previous validation completed

### DIFF
--- a/password.c
+++ b/password.c
@@ -111,6 +111,9 @@ static void submit_password(struct swaylock_state *state) {
 	if (state->args.ignore_empty && state->password.len == 0) {
 		return;
 	}
+	if (state->auth_state == AUTH_STATE_VALIDATING) {
+		return;
+	}
 
 	state->input_state = INPUT_STATE_IDLE;
 	state->auth_state = AUTH_STATE_VALIDATING;


### PR DESCRIPTION
This should resolve #372; while I'm not entirely satisfied with this solution, I think it is a net improvement.

Commit message:
> This averts the risk that one can queue up many password submissions by pressing enter repeatedly (or with key repeat, holding enter), much more quickly than PAM will process them. It may also improve usability by reducing unrevealed system state: now that at most one password can be queued, the "Verifying" message is always shown when a password is being validated.

> However, this commit does introduce a minor UI issue: if one types an invalid second password just slightly faster than PAM validation completes, it may fail to submit, and the signs of this may be hard to notice (state transition timing, presence of keypress indicator, and (if enabled) attempt count).

