### PR TITLE
Stop processing auth requests after success

### DIFF
--- a/pam.c
+++ b/pam.c
@@ -109,6 +109,12 @@ void run_pw_backend_child(void) {
 		if (!write_comm_reply(success)) {
 			exit(EXIT_FAILURE);
 		}
+
+		if (success) {
+			/* Unsuccessful requests may be queued after a successful one;
+			 * do not process them. */
+			break;
+		}
 	}
 
 	pam_setcred(auth_handle, PAM_REFRESH_CRED);


### PR DESCRIPTION
The PAM handling subprocess can receive unsuccessful requests after a successful one. (For example: press enter a few times to build up a queue of empty password attempts, enter a correct password, and then press enter a few times to queue a few more empty password attempts.) Processing the trailing requests is unnecessary, and might cause side effects like those observed in  https://github.com/swaywm/swaylock/issues/377.
