### PR TITLE
Exit when password handling subprocess crashes

### DIFF
--- a/main.c
+++ b/main.c
@@ -1038,6 +1038,9 @@ static void comm_in(int fd, short mask, void *data) {
 	if (read_comm_reply()) {
 		// Authentication succeeded
 		state.run_display = false;
+	} else if (mask & (POLLHUP | POLLERR)) {
+		swaylock_log(LOG_ERROR,	"Password checking subprocess crashed; exiting.");
+		exit(EXIT_FAILURE);
 	} else {
 		state.auth_state = AUTH_STATE_INVALID;
 		schedule_auth_idle(&state);


### PR DESCRIPTION
This change makes swaylock exit immediately when the pam child process crashes or exits early. (Once the child process has crashed, it is no longer possible to unlock the screen; having swaylock exit is now safe because ext-session-lock-v1 is required, and is better than the alternatives of operating in a state where future unlock attempts all fail, or crashing.)

To test this, run swaylock, identify its child process, and `kill` it.

