### PR TITLE
Fix potential NULL deference after getpwuid

### DIFF
--- a/pam.c
+++ b/pam.c
@@ -72,6 +72,11 @@ static const char *get_pam_auth_error(int pam_status) {
 
 void run_pw_backend_child(void) {
 	struct passwd *passwd = getpwuid(getuid());
+	if (!passwd) {
+		swaylock_log_errno(LOG_ERROR, "getpwuid failed");
+		exit(EXIT_FAILURE);
+	}
+
 	char *username = passwd->pw_name;
 
 	const struct pam_conv conv = {


### PR DESCRIPTION
This can happen if swaylock is mistakenly run inside a sandbox without /etc/passwd