### PR TITLE
Better handle subprocess crashes

### DIFF
--- a/comm.c
+++ b/comm.c
@@ -95,13 +95,17 @@ out:
 	return result;
 }
 
-bool read_comm_reply(void) {
-	bool result = false;
-	if (read(comm[1][0], &result, sizeof(result)) != sizeof(result)) {
-		swaylock_log_errno(LOG_ERROR, "Failed to read pw result");
-		result = false;
+bool read_comm_reply(bool *auth_success) {
+	ssize_t n = read(comm[1][0], auth_success, sizeof(*auth_success));
+	if (n != sizeof(*auth_success)) {
+		if (n < 0) {
+			swaylock_log_errno(LOG_ERROR, "Failed to read pw result");
+		} else {
+			swaylock_log(LOG_ERROR, "Failed to read pw result: short read of %zd bytes", n);
+		}
+		return false;
 	}
-	return result;
+	return true;
 }
 
 int get_comm_reply_fd(void) {

--- a/include/comm.h
+++ b/include/comm.h
@@ -11,7 +11,7 @@ bool write_comm_reply(bool success);
 // Requests the provided password to be checked. The password is always cleared
 // when the function returns.
 bool write_comm_request(struct swaylock_password *pw);
-bool read_comm_reply(void);
+bool read_comm_reply(bool *auth_success);
 // FD to poll for password authentication replies.
 int get_comm_reply_fd(void);
 


### PR DESCRIPTION
On my machine EOF doesn't trigger POLLHUP (not sure why), instead read() returns zero. It just prints the following message in a loop:

    [comm.c:101] Failed to read pw result: Success

Better handle this case in read_comm_reply() by making a difference between a failed read() and a failed authentication.