### PR TITLE
Assert that password buffer is NULL-terminated

### DIFF
--- a/comm.c
+++ b/comm.c
@@ -72,6 +72,7 @@ ssize_t read_comm_request(char **buf_ptr) {
 		return -1;
 	}
 
+	assert(buf[size - 1] == '\0');
 	*buf_ptr = buf;
 	return size;
 }


### PR DESCRIPTION
read_comm_request() just copies bytes around. handle_conversation() relies on the fact that the password buffer is NULL-terminated. Make sure that's the case.

---

Motivation: I'm currently debugging this weird issue:

<details>

```
==1084970==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x525000001001 at 
pc 0x786e7aef6e67 bp 0x7ffc967bf7a0 sp 0x7ffc967bef48
READ of size 2 at 0x525000001001 thread T0
    #0 0x786e7aef6e66 in strdup /usr/src/debug/gcc/gcc/libsanitizer/asan/asan_intercep
tors.cpp:576
    #1 0x609c0f77b257 in handle_conversation ../pam.c:41
    #2 0x786e7b4e6091 in pam_vprompt (/usr/lib/libpam.so.0+0xb091) (BuildId: 39294f63e
6e1c425cdaf0d4ddc497350437a09f6)
    #3 0x786e7b4e62dc in pam_prompt (/usr/lib/libpam.so.0+0xb2dc) (BuildId: 39294f63e6
e1c425cdaf0d4ddc497350437a09f6)
    #4 0x786e7b4e6499  (/usr/lib/libpam.so.0+0xb499) (BuildId: 39294f63e6e1c425cdaf0d4
ddc497350437a09f6)
    #5 0x786e78f6442d in pam_sm_authenticate (/usr/lib/security/pam_unix.so+0x742d) (B
uildId: f9c93611daa35533f0667ea1e0298ad84749e926)
    #6 0x786e7b4e422e  (/usr/lib/libpam.so.0+0x922e) (BuildId: 39294f63e6e1c425cdaf0d4
ddc497350437a09f6)
    #7 0x786e7b4e4a47 in pam_authenticate (/usr/lib/libpam.so.0+0x9a47) (BuildId: 3929
4f63e6e1c425cdaf0d4ddc497350437a09f6)
    #8 0x609c0f77b6ea in run_pw_backend_child ../pam.c:99
    #9 0x609c0f75dde1 in spawn_comm_child ../comm.c:65
    #10 0x609c0f77aff9 in initialize_pw_backend ../pam.c:22
    #11 0x609c0f76cfe1 in main ../main.c:1081
    #12 0x786e7a435487  (/usr/lib/libc.so.6+0x27487) (BuildId: 0b707b217b15b106c25fe51
df3724b25848310c0)
    #13 0x786e7a43554b in __libc_start_main (/usr/lib/libc.so.6+0x2754b) (BuildId: 0b7
07b217b15b106c25fe51df3724b25848310c0)
    #14 0x609c0f75bb94 in _start (/home/simon/src/swaylock/build/swaylock+0x30b94) (Bu
ildId: 6a680039fc5c067bef30eee89b159aaabe50b7a3)

0x525000001001 is located 0 bytes after 1-byte region [0x525000001000,0x525000001001)
allocated by thread T0 here:
    #0 0x786e7aefcbd7 in posix_memalign /usr/src/debug/gcc/gcc/libsanitizer/asan/asan_malloc_linux.cpp:145
    #1 0x609c0f770ac7 in password_buffer_create ../password-buffer.c:60
    #2 0x609c0f75d723 in read_comm_request ../comm.c:23
    #3 0x609c0f77b676 in run_pw_backend_child ../pam.c:92
    #4 0x609c0f75dde1 in spawn_comm_child ../comm.c:65
    #5 0x609c0f77aff9 in initialize_pw_backend ../pam.c:22
    #6 0x609c0f76cfe1 in main ../main.c:1081
    #7 0x786e7a435487  (/usr/lib/libc.so.6+0x27487) (BuildId: 0b707b217b15b106c25fe51df3724b25848310c0)
    #8 0x786e7a43554b in __libc_start_main (/usr/lib/libc.so.6+0x2754b) (BuildId: 0b707b217b15b106c25fe51df3724b25848310c0)
    #9 0x609c0f75bb94 in _start (/home/simon/src/swaylock/build/swaylock+0x30b94) (BuildId: 6a680039fc5c067bef30eee89b159aaabe50b7a3)
```

</details>