### PR TITLE
Define _POSIX_C_SOURCE globally and detect supported warnings

### DIFF
--- a/log.c
+++ b/log.c
@@ -1,4 +1,3 @@
-#define _POSIX_C_SOURCE 199506L
 #include <errno.h>
 #include <stdarg.h>
 #include <stdio.h>

--- a/loop.c
+++ b/loop.c
@@ -1,4 +1,3 @@
-#define _POSIX_C_SOURCE 200809L
 #include <limits.h>
 #include <string.h>
 #include <stdbool.h>

--- a/main.c
+++ b/main.c
@@ -1,4 +1,3 @@
-#define _POSIX_C_SOURCE 200809L
 #include <assert.h>
 #include <ctype.h>
 #include <errno.h>

--- a/meson.build
+++ b/meson.build
@@ -11,22 +11,18 @@ project(
 	],
 )
 
-add_project_arguments('-D_POSIX_C_SOURCE=200809L', language: 'c')
-
-add_project_arguments(
-	[
-		'-Wno-unused-parameter',
-		'-Wno-unused-result',
-		'-Wundef',
-		'-Wvla',
-	],
-	language: 'c',
-)
-
 cc = meson.get_compiler('c')
 
-is_freebsd = host_machine.system().startswith('freebsd')
+add_project_arguments('-D_POSIX_C_SOURCE=200809L', language: 'c')
 
+add_project_arguments(cc.get_supported_arguments([
+	'-Wno-unused-parameter',
+	'-Wno-unused-result',
+	'-Wundef',
+	'-Wvla',
+]), language: 'c')
+
+is_freebsd = host_machine.system().startswith('freebsd')
 if is_freebsd
 	add_project_arguments('-D_C11_SOURCE', language: 'c')
 endif

--- a/meson.build
+++ b/meson.build
@@ -11,6 +11,8 @@ project(
 	],
 )
 
+add_project_arguments('-D_POSIX_C_SOURCE=200809L', language: 'c')
+
 add_project_arguments(
 	[
 		'-Wno-unused-parameter',

--- a/password-buffer.c
+++ b/password-buffer.c
@@ -1,4 +1,3 @@
-#define _POSIX_C_SOURCE 200809L
 #include "password-buffer.h"
 #include "log.h"
 #include "swaylock.h"

--- a/pool-buffer.c
+++ b/pool-buffer.c
@@ -1,4 +1,3 @@
-#define _POSIX_C_SOURCE 200809L
 #include <assert.h>
 #include <cairo/cairo.h>
 #include <errno.h>

--- a/shadow.c
+++ b/shadow.c
@@ -1,3 +1,4 @@
+#undef _POSIX_C_SOURCE
 #define _XOPEN_SOURCE // for crypt
 #include <assert.h>
 #include <pwd.h>


### PR DESCRIPTION
### Define _POSIX_C_SOURCE globally

Other Sway projects have switched to this approach.

### build: use cc.get_supported_arguments() for warnings

Let's not require the C compiler to support specific warnings,
especially if half the flags are used to turn off the warnings
anyways.