### PR TITLE
comm: assert that password size is positive

### DIFF
--- a/comm.c
+++ b/comm.c
@@ -59,6 +59,7 @@ ssize_t read_comm_request(char **buf_ptr) {
 	if (n <= 0) {
 		return n;
 	}
+	assert(size > 0);
 
 	swaylock_log(LOG_DEBUG, "received pw check request");
 


### PR DESCRIPTION
If it's not, we may be reading before the buffer bounds later. (The password buffer size is aligned to the page size.)