### PR TITLE
Ignore SIGUSR1 in the backend child process

### DIFF
--- a/comm.c
+++ b/comm.c
@@ -96,6 +96,10 @@ bool spawn_comm_child(void) {
 		swaylock_log_errno(LOG_ERROR, "failed to fork");
 		return false;
 	} else if (child == 0) {
+		struct sigaction sa = {
+			.sa_handler = SIG_IGN,
+		};
+		sigaction(SIGUSR1, &sa, NULL);
 		close(comm[0][1]);
 		close(comm[1][0]);
 		run_pw_backend_child();


### PR DESCRIPTION
If a user calls `killall -USR1 swaylock`, they may end up signalling the password backend. As the password backend forked before SIGUSR1 handling was set up, it inherits the default handler and terminates.

Set the SIGUSR1 handler to SIG_IGN in the child process.

Fixes: https://github.com/swaywm/swaylock/issues/409