### PR TITLE
main: change background color to #a3a3a3

### DIFF
--- a/main.c
+++ b/main.c
@@ -397,7 +397,7 @@ static void load_image(char *arg, struct swaylock_state *state) {
 }
 
 static void set_default_colors(struct swaylock_colors *colors) {
-	colors->background = 0xFFFFFFFF;
+	colors->background = 0xA3A3A3FF;
 	colors->bs_highlight = 0xDB3300FF;
 	colors->key_highlight = 0x33DB00FF;
 	colors->caps_lock_bs_highlight = 0xDB3300FF;
@@ -546,7 +546,7 @@ static int parse_options(int argc, char **argv, struct swaylock_state *state,
 		"  -C, --config <config_file>       "
 			"Path to the config file.\n"
 		"  -c, --color <color>              "
-			"Turn the screen into the given color instead of white.\n"
+			"Turn the screen into the given color instead of light gray.\n"
 		"  -d, --debug                      "
 			"Enable debugging output.\n"
 		"  -e, --ignore-empty-password      "

--- a/swaylock.1.scd
+++ b/swaylock.1.scd
@@ -80,9 +80,9 @@ Locks your Wayland session.
 	Same as --scaling=tile.
 
 *-c, --color* <rrggbb[aa]>
-	Turn the screen into the given color instead of white. If -i is used, this
-	sets the background of the image to the given color. Defaults to white
-	(FFFFFF).
+	Turn the screen into the given color instead of light gray. If -i is used,
+	this sets the background of the image to the given color. Defaults to light
+	gray (A3A3A3).
 
 *--bs-hl-color* <rrggbb[aa]>
 	Sets the color of backspace highlight segments.


### PR DESCRIPTION
This is a port of the change I made to i3lock a couple of years ago, see: https://github.com/i3/i3lock/pull/300/commits

FFFFFF can cause varying degrees of uncomfortableness to users like me, especially during night time. Uncomfortableness can mean "migraines" or being woken up if the electric wiring is suboptimal, causing a desktop to wake up (the latter of which is why I opened the i3lock PR, despite the effort associated with changing defaults).

However, the choice of a color that is not solid white helps users tell whether their computer is turned off or not. Light gray (#a3a3a3) is a compromise that is bright, but not "flashbang levels" of bright.

This compromise was met after a long discussion with the i3lock developers, and, given the similarities between i3lock and swaylock, this change could be sensible for swaylock as well.