### PR TITLE
Make PAM optional at runtime

### DIFF
--- a/.build.yml
+++ b/.build.yml
@@ -14,10 +14,14 @@ tasks:
   - setup: |
       cd swaylock
       meson build
-  - build: |
+  - build-both: |
       cd swaylock
       ninja -C build
-  - build-no-pam: |
+  - build-pam: |
       cd swaylock
-      meson configure build -Dpam=disabled
+      meson build-pam -Dshadow=disabled
+      ninja -C build
+  - build-shadow: |
+      cd swaylock
+      meson build-shadow -Dpam=disabled
       ninja -C build

--- a/backend.c
+++ b/backend.c
@@ -1,0 +1,64 @@
+#include "swaylock.h"
+#include "log.h"
+#include "config.h"
+#include <stdlib.h>
+
+#if !HAVE_PAM
+bool load_pam_library(void) {
+	return false;
+}
+
+bool is_pam_loaded(void) {
+	return false;
+}
+
+void initialize_pam_backend(int argc, char **argv) {
+	// Stub function - should never be called
+}
+
+void run_pam_backend_child(void) {
+	// Stub function - should never be called
+}
+#endif
+
+#if !HAVE_SHADOW
+void initialize_shadow_backend(int argc, char **argv) {
+	// Stub function - should never be called
+}
+
+void run_shadow_backend_child(void) {
+	// Stub function - should never be called
+}
+#endif
+
+void initialize_pw_backend(int argc, char **argv) {
+#if HAVE_PAM
+	if (load_pam_library()) {
+		swaylock_log(LOG_ERROR, "Initialising pam");
+		initialize_pam_backend(argc, argv);
+		return;
+	}
+#endif
+#if HAVE_SHADOW
+	swaylock_log(LOG_ERROR, "Initialising shadow");
+	initialize_shadow_backend(argc, argv);
+#else
+	swaylock_log(LOG_ERROR, "No authentication backend available");
+	exit(EXIT_FAILURE);
+#endif
+}
+
+void run_pw_backend_child(void) {
+#if HAVE_PAM
+	if (is_pam_loaded()) {
+		run_pam_backend_child();
+		return;
+	}
+#endif
+#if HAVE_SHADOW
+	run_shadow_backend_child();
+#else
+	swaylock_log(LOG_ERROR, "No authentication backend available");
+	exit(EXIT_FAILURE);
+#endif
+}

--- a/include/swaylock.h
+++ b/include/swaylock.h
@@ -140,8 +140,15 @@ void damage_state(struct swaylock_state *state);
 void clear_password_buffer(struct swaylock_password *pw);
 void schedule_auth_idle(struct swaylock_state *state);
 
+bool load_pam_library(void);
+bool is_pam_loaded(void);
+
 void initialize_pw_backend(int argc, char **argv);
+void initialize_pam_backend(int argc, char **argv);
+void initialize_shadow_backend(int argc, char **argv);
 void run_pw_backend_child(void);
+void run_pam_backend_child(void);
+void run_shadow_backend_child(void);
 void clear_buffer(char *buf, size_t size);
 
 #endif

--- a/main.c
+++ b/main.c
@@ -1062,7 +1062,7 @@ static void term_in(int fd, short mask, void *data) {
 }
 
 // Check for --debug 'early' we also apply the correct loglevel
-// to the forked child, without having to first proces all of the
+// to the forked child, without having to first process all of the
 // configuration (including from file) before forking and (in the
 // case of the shadow backend) dropping privileges
 void log_init(int argc, char **argv) {

--- a/meson.build
+++ b/meson.build
@@ -79,6 +79,8 @@ conf_data = configuration_data()
 conf_data.set_quoted('SYSCONFDIR', get_option('prefix') / get_option('sysconfdir'))
 conf_data.set_quoted('SWAYLOCK_VERSION', version)
 conf_data.set10('HAVE_GDK_PIXBUF', gdk_pixbuf.found())
+conf_data.set10('HAVE_PAM', libpam.found())
+conf_data.set10('HAVE_SHADOW', get_option('shadow').enabled())
 
 subdir('include')
 
@@ -93,6 +95,7 @@ dependencies = [
 
 sources = [
 	'background-image.c',
+	'backend.c',
 	'cairo.c',
 	'comm.c',
 	'log.c',
@@ -108,12 +111,18 @@ sources = [
 
 if libpam.found()
 	sources += ['pam.c']
-else
-	warning('The swaylock binary often needs to be setuid when compiled without libpam')
+endif
+
+if get_option('shadow').enabled()
+	warning('The swaylock binary must be setuid when compiled without libpam')
 	warning('You must do this manually post-install: chmod a+s /path/to/swaylock')
 	warning('See the "Without PAM" section of the README for details.')
 	sources += ['shadow.c']
 	dependencies += [crypt]
+endif
+
+if not libpam.found() and not get_option('shadow').enabled()
+	error('At least one of PAM or shadow support must be enabled.')
 endif
 
 swaylock_inc = include_directories('include')
@@ -156,3 +165,8 @@ if scdoc.found()
 endif
 
 subdir('completions')
+
+summary({
+	'pam': libpam.found(),
+	'shadow': get_option('shadow').enabled(),
+}, bool_yn: true)

--- a/meson.build
+++ b/meson.build
@@ -108,7 +108,6 @@ sources = [
 
 if libpam.found()
 	sources += ['pam.c']
-	dependencies += [libpam]
 else
 	warning('The swaylock binary often needs to be setuid when compiled without libpam')
 	warning('You must do this manually post-install: chmod a+s /path/to/swaylock')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,4 +1,5 @@
-option('pam', type: 'feature', value: 'auto', description: 'Use PAM instead of shadow')
+option('pam', type: 'feature', value: 'auto', description: 'Enabled PAM support')
+option('shadow', type: 'feature', value: 'enabled', description: 'Enabled shadow support')
 option('gdk-pixbuf', type: 'feature', value: 'auto', description: 'Enable support for more image formats')
 option('man-pages', type: 'feature', value: 'auto', description: 'Generate and install man pages')
 option('zsh-completions', type: 'boolean', value: true, description: 'Install zsh shell completions')

--- a/pam.c
+++ b/pam.c
@@ -1,15 +1,53 @@
 #define _POSIX_C_SOURCE 200809L
+#include <dlfcn.h>
 #include <pwd.h>
 #include <security/pam_appl.h>
 #include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
+
 #include "comm.h"
 #include "log.h"
 #include "password-buffer.h"
 #include "swaylock.h"
 
+static char *pw_buf = NULL;
+static void *pam_handle = NULL;
+
+// Function pointers for PAM symbols
+static int (*fp_pam_start)(const char *, const char *, const struct pam_conv *, pam_handle_t **) = NULL;
+static int (*fp_pam_authenticate)(pam_handle_t *, int) = NULL;
+static int (*fp_pam_end)(pam_handle_t *, int) = NULL;
+static int (*fp_pam_setcred)(pam_handle_t *, int) = NULL;
+
+static bool load_pam_library(void) {
+	pam_handle = dlopen("libpam.so.0", RTLD_NOW);
+	if (!pam_handle) {
+		swaylock_log(LOG_ERROR, "Failed to load libpam.so.0: %s", dlerror());
+		return false;
+	}
+
+	fp_pam_start = dlsym(pam_handle, "pam_start");
+	fp_pam_authenticate = dlsym(pam_handle, "pam_authenticate");
+	fp_pam_end = dlsym(pam_handle, "pam_end");
+	fp_pam_setcred = dlsym(pam_handle, "pam_setcred");
+
+	if (!fp_pam_start || !fp_pam_authenticate || !fp_pam_end || !fp_pam_setcred) {
+		swaylock_log(LOG_ERROR, "Failed to load one or more PAM symbols");
+		dlclose(pam_handle);
+		pam_handle = NULL;
+		return false;
+	}
+	return true;
+}
+
+static void unload_pam_library(void) {
+	if (pam_handle) {
+		dlclose(pam_handle);
+		pam_handle = NULL;
+	}
+}
 void initialize_pw_backend(int argc, char **argv) {
 	if (getuid() != geteuid() || getgid() != getegid()) {
 		swaylock_log(LOG_ERROR,
@@ -82,10 +120,14 @@ static const char *get_pam_auth_error(int pam_status) {
 }
 
 void run_pw_backend_child(void) {
-	char *pw_buf = NULL;
+	if (!load_pam_library()) {
+		exit(EXIT_FAILURE);  // Fall back or exit if desired
+	}
+
 	struct passwd *passwd = getpwuid(getuid());
 	if (!passwd) {
 		swaylock_log_errno(LOG_ERROR, "getpwuid failed");
+		unload_pam_library();
 		exit(EXIT_FAILURE);
 	}
 
@@ -97,8 +139,9 @@ void run_pw_backend_child(void) {
 		.appdata_ptr = &state,
 	};
 	pam_handle_t *auth_handle = NULL;
-	if (pam_start("swaylock", username, &conv, &auth_handle) != PAM_SUCCESS) {
+	if (fp_pam_start("swaylock", username, &conv, &auth_handle) != PAM_SUCCESS) {
 		swaylock_log(LOG_ERROR, "pam_start failed");
+		unload_pam_library();
 		exit(EXIT_FAILURE);
 	}
 
@@ -115,7 +158,7 @@ void run_pw_backend_child(void) {
 		}
 
 		state.password = pw_buf;
-		int pam_status = pam_authenticate(auth_handle, 0);
+		int pam_status = fp_pam_authenticate(auth_handle, 0);
 		password_buffer_destroy(pw_buf, size);
 		pw_buf = NULL;
 		state.password = NULL;
@@ -137,12 +180,14 @@ void run_pw_backend_child(void) {
 		}
 	}
 
-	pam_setcred(auth_handle, PAM_REFRESH_CRED);
+	fp_pam_setcred(auth_handle, PAM_REFRESH_CRED);
 
-	if (pam_end(auth_handle, pam_status) != PAM_SUCCESS) {
+	if (fp_pam_end(auth_handle, pam_status) != PAM_SUCCESS) {
 		swaylock_log(LOG_ERROR, "pam_end failed");
+		unload_pam_library();
 		exit(EXIT_FAILURE);
 	}
 
+	unload_pam_library();
 	exit((pam_status == PAM_SUCCESS) ? EXIT_SUCCESS : EXIT_FAILURE);
 }

--- a/pam.c
+++ b/pam.c
@@ -21,7 +21,7 @@ static int (*fp_pam_authenticate)(pam_handle_t *, int) = NULL;
 static int (*fp_pam_end)(pam_handle_t *, int) = NULL;
 static int (*fp_pam_setcred)(pam_handle_t *, int) = NULL;
 
-static bool load_pam_library(void) {
+bool load_pam_library(void) {
 	pam_handle = dlopen("libpam.so.0", RTLD_NOW);
 	if (!pam_handle) {
 		swaylock_log(LOG_ERROR, "Failed to load libpam.so.0: %s", dlerror());
@@ -42,13 +42,18 @@ static bool load_pam_library(void) {
 	return true;
 }
 
+bool is_pam_loaded(void) {
+	return pam_handle != NULL;
+}
+
 static void unload_pam_library(void) {
 	if (pam_handle) {
 		dlclose(pam_handle);
 		pam_handle = NULL;
 	}
 }
-void initialize_pw_backend(int argc, char **argv) {
+
+void initialize_pam_backend(int argc, char **argv) {
 	if (getuid() != geteuid() || getgid() != getegid()) {
 		swaylock_log(LOG_ERROR,
 			"swaylock is setuid, but was compiled with the PAM"
@@ -119,11 +124,7 @@ static const char *get_pam_auth_error(int pam_status) {
 	}
 }
 
-void run_pw_backend_child(void) {
-	if (!load_pam_library()) {
-		exit(EXIT_FAILURE);  // Fall back or exit if desired
-	}
-
+void run_pam_backend_child(void) {
 	struct passwd *passwd = getpwuid(getuid());
 	if (!passwd) {
 		swaylock_log_errno(LOG_ERROR, "getpwuid failed");

--- a/shadow.c
+++ b/shadow.c
@@ -18,7 +18,7 @@
 
 char *encpw = NULL;
 
-void initialize_pw_backend(int argc, char **argv) {
+void initialize_shadow_backend(int argc, char **argv) {
 	/* This code runs as root */
 	struct passwd *pwent = getpwuid(getuid());
 	if (!pwent) {
@@ -61,7 +61,7 @@ void initialize_pw_backend(int argc, char **argv) {
 	encpw = NULL;
 }
 
-void run_pw_backend_child(void) {
+void run_shadow_backend_child(void) {
 	assert(encpw != NULL);
 	while (1) {
 		char *buf;


### PR DESCRIPTION
swaylock links to PAM directly, so the same binary cannot be used in scenarios where PAM is not installed.

Load PAM at runtime, to enable using the same binary when PAM is not available. Use shadow as a fallback if PAM is not available.

This allows enabling both the `shadow` and `pam` backend at compile-time, but if PAM is not available at runtime, shadow is used as a fallback. This is particularly useful for distribution packages where some users rely on PAM and others do not use PAM.

I've successfully tested this on Alpine. The same binary works with or without PAM.