### PR TITLE
check for pending callback on destroy_surface

### DIFF
--- a/main.c
+++ b/main.c
@@ -92,6 +92,9 @@ static void daemonize(void) {
 }
 
 static void destroy_surface(struct swaylock_surface *surface) {
+	if (surface->frame != NULL) {
+		wl_callback_destroy(surface->frame);
+	}
 	wl_list_remove(&surface->link);
 	if (surface->ext_session_lock_surface_v1 != NULL) {
 		ext_session_lock_surface_v1_destroy(surface->ext_session_lock_surface_v1);


### PR DESCRIPTION
Avoids segfaults when a pending surface_frame_handle_done is invoked after destruction of the associated surface.

This happened when an output was removed and the surfaces have been destroyed in between render and  surface_frame_handle_done.