### PR TITLE
Wait for surface presentation before daemonizing

### DIFF
--- a/include/swaylock.h
+++ b/include/swaylock.h
@@ -69,6 +69,7 @@ struct swaylock_args {
 	bool daemonize;
 	int ready_fd;
 	bool indicator_idle_visible;
+	bool await_render;
 };
 
 struct swaylock_password {
@@ -100,6 +101,7 @@ struct swaylock_state {
 	bool run_display, locked;
 	struct ext_session_lock_manager_v1 *ext_session_lock_manager_v1;
 	struct ext_session_lock_v1 *ext_session_lock_v1;
+	struct wp_presentation *presentation;
 };
 
 struct swaylock_surface {
@@ -114,6 +116,7 @@ struct swaylock_surface {
 	struct pool_buffer indicator_buffers[2];
 	bool created;
 	bool dirty;
+	bool presented;
 	uint32_t width, height;
 	int32_t scale;
 	enum wl_output_subpixel subpixel;

--- a/meson.build
+++ b/meson.build
@@ -66,6 +66,7 @@ wayland_scanner_client = generator(
 )
 
 client_protocols = [
+	wl_protocol_dir / 'stable/presentation-time/presentation-time.xml',
 	wl_protocol_dir / 'staging/ext-session-lock/ext-session-lock-v1.xml',
 ]
 


### PR DESCRIPTION
We currently wait for the session to enter the "locked" state before setting the ready state and daemonizing. Lock surface configuration and rendition happens in paralle with this, and there is no guarantee that all displays have had new frames submitted at this point.

Instead, use presentation-time to wait for a single `presented` event on all surfaces, or surface removal, before continuing.