### PR TITLE
Update layout indicator as soon as layout changes

### DIFF
--- a/seat.c
+++ b/seat.c
@@ -92,14 +92,11 @@ static void keyboard_modifiers(void *data, struct wl_keyboard *wl_keyboard,
 
 	int layout_same = xkb_state_layout_index_is_active(state->xkb.state,
 		group, XKB_STATE_LAYOUT_EFFECTIVE);
-	if (!layout_same) {
-		damage_state(state);
-	}
 	xkb_state_update_mask(state->xkb.state,
 		mods_depressed, mods_latched, mods_locked, 0, 0, group);
 	int caps_lock = xkb_state_mod_name_is_active(state->xkb.state,
 		XKB_MOD_NAME_CAPS, XKB_STATE_MODS_LOCKED);
-	if (caps_lock != state->xkb.caps_lock) {
+	if (caps_lock != state->xkb.caps_lock || !layout_same) {
 		state->xkb.caps_lock = caps_lock;
 		damage_state(state);
 	}


### PR DESCRIPTION
Wait till after `xkb_state_update_mask` before rendering so that when
`render_frame` sees the changed keyboard layout state. (Otherwise the
layout indicator shows what the layout was before the modifier event.)
