### PR TITLE
Clarify setup instructions without PAM

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,24 @@ Run these commands:
     ninja -C build
     sudo ninja -C build install
 
-On systems without PAM, you need to suid the swaylock binary:
+##### Without PAM
+
+On systems without PAM, swaylock uses `shadow.h`.
+
+Systems which rely on a tcb-like setup (either via musl's native support or via
+glibc+[tcb]), require no further action.
+
+[tcb]: https://www.openwall.com/tcb/
+
+For most other systems, where passwords for all users are stored in `/etc/shadow`,
+swaylock needs to be installed suid:
 
     sudo chmod a+s /usr/local/bin/swaylock
+
+Optionally, on systems where the file `/etc/shadow` is owned by the `shadow`
+group, the binary can be made sgid instead:
+
+    sudo chgrp shadow /usr/local/bin/swaylock
+    sudo chmod g+s /usr/local/bin/swaylock
 
 Swaylock will drop root permissions shortly after startup.

--- a/meson.build
+++ b/meson.build
@@ -110,8 +110,9 @@ if libpam.found()
 	sources += ['pam.c']
 	dependencies += [libpam]
 else
-	warning('The swaylock binary must be setuid when compiled without libpam')
+	warning('The swaylock binary often needs to be setuid when compiled without libpam')
 	warning('You must do this manually post-install: chmod a+s /path/to/swaylock')
+	warning('See the "Without PAM" section of the README for details.')
 	sources += ['shadow.c']
 	dependencies += [crypt]
 endif


### PR DESCRIPTION
- Mention that using a TCB-like setup doesn't require SUID.
- Recommend using SGID instead of SUID.