### PR TITLE
Use bright black rather than black for LOG_DEBUG

### DIFF
--- a/log.c
+++ b/log.c
@@ -13,7 +13,7 @@ static const char *verbosity_colors[] = {
 	[LOG_SILENT] = "",
 	[LOG_ERROR ] = "\x1B[1;31m",
 	[LOG_INFO  ] = "\x1B[1;34m",
-	[LOG_DEBUG ] = "\x1B[1;30m",
+	[LOG_DEBUG ] = "\x1B[1;90m",
 };
 
 void swaylock_log_init(enum log_importance verbosity) {


### PR DESCRIPTION
This makes swaylock's log colors consistent with sway (which was changed a few years ago by https://github.com/swaywm/sway/pull/5375), swaybg, and swayidle (the latter two updated recently to match, most recently https://github.com/swaywm/swaybg/pull/95 .)