### PR TITLE
Implement --extra-auth-command

### DIFF
--- a/include/swaylock.h
+++ b/include/swaylock.h
@@ -100,6 +100,8 @@ struct swaylock_state {
 	bool run_display, locked;
 	struct ext_session_lock_manager_v1 *ext_session_lock_manager_v1;
 	struct ext_session_lock_v1 *ext_session_lock_v1;
+	char *auth_command_path;
+	pid_t auth_command_pid;
 };
 
 struct swaylock_surface {

--- a/swaylock.1.scd
+++ b/swaylock.1.scd
@@ -196,6 +196,9 @@ Locks your Wayland session.
 *--text-wrong-color* <rrggbb[aa]>
 	Sets the color of the text when invalid.
 
+*--extra-auth-command* <command>
+	Sets a command to run for extra authentication.
+
 # SIGNALS
 
 *SIGUSR1*


### PR DESCRIPTION
- **Handle SIGCHLD.**
- **Implement --extra-auth-command.**

This is being proposed as an alternative to #283.
Fingerprint authentication can be done with:

    swaylock --extra-auth-command `which fprintd-verify`

CC @emersion @SL-RU

The bit that needs discussion is the case of failure of the authentication command.  We currently restart the command, which allows using an unmodified fpritd-verify.  A perhaps better solution would be to disable the extra auth command, as we currently do when it crashes.  This will force us to write our own custom wrapper around fprintd-verify, but should be slightly more robust.
