### PR TITLE
add a basic alphanumeric on-screen keyboard

### DIFF
--- a/include/keypad_layout.h
+++ b/include/keypad_layout.h
@@ -1,0 +1,23 @@
+#ifndef _SWAYLOCK_KEYPAD_LAYOUT_H
+#define _SWAYLOCK_KEYPAD_LAYOUT_H
+
+#define KEYPAD_ROWS 5
+#define KEYPAD_COLS 10
+
+static const char *keypad_layout_base[KEYPAD_ROWS][KEYPAD_COLS] = {
+	{"1", "2", "3", "4", "5", "6", "7", "8", "9", "0"},
+	{"q", "w", "e", "r", "t", "y", "u", "i", "o", "p"},
+	{"a", "s", "d", "f", "g", "h", "j", "k", "l", ";"},
+	{"z", "x", "c", "v", "b", "n", "m", ",", ".", "/"},
+	{"Go", "Del", "Alt", "", "", "", "", "", "", ""},
+};
+
+static const char *keypad_layout_upper[KEYPAD_ROWS][KEYPAD_COLS] = {
+	{"!", "@", "#", "$", "%", "^", "&", "*", "(", ")"},
+	{"Q", "W", "E", "R", "T", "Y", "U", "I", "O", "P"},
+	{"A", "S", "D", "F", "G", "H", "J", "K", "L", ":"},
+	{"Z", "X", "C", "V", "B", "N", "M", "<", ">", "?"},
+	{"Go", "Del", "Alt", "", "", "", "", "", "", ""},
+};
+
+#endif

--- a/include/seat.h
+++ b/include/seat.h
@@ -3,9 +3,11 @@
 #include <xkbcommon/xkbcommon.h>
 #include <stdint.h>
 #include <stdbool.h>
+#include <wayland-client.h>
 
 struct loop;
 struct loop_timer;
+struct swaylock_surface;
 
 struct swaylock_xkb {
 	bool caps_lock;
@@ -19,6 +21,10 @@ struct swaylock_seat {
 	struct swaylock_state *state;
 	struct wl_pointer *pointer;
 	struct wl_keyboard *keyboard;
+	struct wl_surface *pointer_wl_surface;
+	struct swaylock_surface *pointer_surface;
+	double pointer_x;
+	double pointer_y;
 	int32_t repeat_period_ms;
 	int32_t repeat_delay_ms;
 	uint32_t repeat_sym;

--- a/include/swaylock.h
+++ b/include/swaylock.h
@@ -42,6 +42,7 @@ struct swaylock_colors {
 	uint32_t layout_background;
 	uint32_t layout_border;
 	uint32_t layout_text;
+	uint32_t keypad_text;
 	struct swaylock_colorset inside;
 	struct swaylock_colorset line;
 	struct swaylock_colorset ring;
@@ -69,6 +70,7 @@ struct swaylock_args {
 	bool daemonize;
 	int ready_fd;
 	bool indicator_idle_visible;
+	bool show_keypad;
 };
 
 struct swaylock_password {
@@ -97,6 +99,7 @@ struct swaylock_state {
 	enum input_state input_state; // state of the password buffer and key inputs
 	uint32_t highlight_start; // position of highlight; 2048 = 1 full turn
 	int failed_attempts;
+	bool keypad_upper;
 	bool run_display, locked;
 	struct ext_session_lock_manager_v1 *ext_session_lock_manager_v1;
 	struct ext_session_lock_v1 *ext_session_lock_v1;
@@ -110,11 +113,16 @@ struct swaylock_surface {
 	struct wl_surface *surface; // surface for background
 	struct wl_surface *child; // indicator surface made into subsurface
 	struct wl_subsurface *subsurface;
+	struct wl_surface *keypad_child; // keypad surface made into subsurface
+	struct wl_subsurface *keypad_subsurface;
 	struct ext_session_lock_surface_v1 *ext_session_lock_surface_v1;
 	struct pool_buffer indicator_buffers[2];
+	struct pool_buffer keypad_buffers[2];
 	bool created;
 	bool dirty;
 	uint32_t width, height;
+	int32_t keypad_x, keypad_y;
+	uint32_t keypad_width, keypad_height;
 	int32_t scale;
 	enum wl_output_subpixel subpixel;
 	char *output_name;
@@ -139,6 +147,9 @@ void render(struct swaylock_surface *surface);
 void damage_state(struct swaylock_state *state);
 void clear_password_buffer(struct swaylock_password *pw);
 void schedule_auth_idle(struct swaylock_state *state);
+void swaylock_handle_keypad_key(struct swaylock_state *state, const char *key);
+void swaylock_handle_pointer_click(struct swaylock_state *state,
+		struct swaylock_surface *surface, double x, double y);
 
 void initialize_pw_backend(int argc, char **argv);
 void run_pw_backend_child(void);

--- a/main.c
+++ b/main.c
@@ -102,14 +102,22 @@ static void destroy_surface(struct swaylock_surface *surface) {
 	if (surface->subsurface) {
 		wl_subsurface_destroy(surface->subsurface);
 	}
+	if (surface->keypad_subsurface) {
+		wl_subsurface_destroy(surface->keypad_subsurface);
+	}
 	if (surface->child) {
 		wl_surface_destroy(surface->child);
+	}
+	if (surface->keypad_child) {
+		wl_surface_destroy(surface->keypad_child);
 	}
 	if (surface->surface != NULL) {
 		wl_surface_destroy(surface->surface);
 	}
 	destroy_buffer(&surface->indicator_buffers[0]);
 	destroy_buffer(&surface->indicator_buffers[1]);
+	destroy_buffer(&surface->keypad_buffers[0]);
+	destroy_buffer(&surface->keypad_buffers[1]);
 	wl_output_release(surface->output);
 	free(surface);
 }
@@ -139,6 +147,13 @@ static void create_surface(struct swaylock_surface *surface) {
 	surface->subsurface = wl_subcompositor_get_subsurface(state->subcompositor, surface->child, surface->surface);
 	assert(surface->subsurface);
 	wl_subsurface_set_sync(surface->subsurface);
+
+	surface->keypad_child = wl_compositor_create_surface(state->compositor);
+	assert(surface->keypad_child);
+	surface->keypad_subsurface = wl_subcompositor_get_subsurface(
+		state->subcompositor, surface->keypad_child, surface->surface);
+	assert(surface->keypad_subsurface);
+	wl_subsurface_set_sync(surface->keypad_subsurface);
 
 	surface->ext_session_lock_surface_v1 = ext_session_lock_v1_get_lock_surface(
 		state->ext_session_lock_v1, surface->surface, surface->output);
@@ -409,6 +424,7 @@ static void set_default_colors(struct swaylock_colors *colors) {
 	colors->layout_background = 0x000000C0;
 	colors->layout_border = 0x00000000;
 	colors->layout_text = 0xFFFFFFFF;
+	colors->keypad_text = 0x000000FF;
 	colors->inside = (struct swaylock_colorset){
 		.input = 0x000000C0,
 		.cleared = 0xE5A445C0,
@@ -464,6 +480,7 @@ static int parse_options(int argc, char **argv, struct swaylock_state *state,
 		LO_INSIDE_VER_COLOR,
 		LO_INSIDE_WRONG_COLOR,
 		LO_KEY_HL_COLOR,
+		LO_KEYPAD_TEXT_COLOR,
 		LO_LAYOUT_TXT_COLOR,
 		LO_LAYOUT_BG_COLOR,
 		LO_LAYOUT_BORDER_COLOR,
@@ -483,6 +500,7 @@ static int parse_options(int argc, char **argv, struct swaylock_state *state,
 		LO_TEXT_CAPS_LOCK_COLOR,
 		LO_TEXT_VER_COLOR,
 		LO_TEXT_WRONG_COLOR,
+		LO_SHOW_KEYPAD,
 	};
 
 	static struct option long_options[] = {
@@ -521,6 +539,7 @@ static int parse_options(int argc, char **argv, struct swaylock_state *state,
 		{"inside-ver-color", required_argument, NULL, LO_INSIDE_VER_COLOR},
 		{"inside-wrong-color", required_argument, NULL, LO_INSIDE_WRONG_COLOR},
 		{"key-hl-color", required_argument, NULL, LO_KEY_HL_COLOR},
+		{"keypad-text-color", required_argument, NULL, LO_KEYPAD_TEXT_COLOR},
 		{"layout-bg-color", required_argument, NULL, LO_LAYOUT_BG_COLOR},
 		{"layout-border-color", required_argument, NULL, LO_LAYOUT_BORDER_COLOR},
 		{"layout-text-color", required_argument, NULL, LO_LAYOUT_TXT_COLOR},
@@ -540,6 +559,7 @@ static int parse_options(int argc, char **argv, struct swaylock_state *state,
 		{"text-caps-lock-color", required_argument, NULL, LO_TEXT_CAPS_LOCK_COLOR},
 		{"text-ver-color", required_argument, NULL, LO_TEXT_VER_COLOR},
 		{"text-wrong-color", required_argument, NULL, LO_TEXT_WRONG_COLOR},
+		{"show-keypad", no_argument, NULL, LO_SHOW_KEYPAD},
 		{0, 0, 0, 0}
 	};
 
@@ -615,6 +635,8 @@ static int parse_options(int argc, char **argv, struct swaylock_state *state,
 			"Sets the color of the inside of the indicator when invalid.\n"
 		"  --key-hl-color <color>           "
 			"Sets the color of the key press highlight segments.\n"
+		"  --keypad-text-color <color>      "
+			"Sets the color of on-screen keyboard key labels.\n"
 		"  --layout-bg-color <color>        "
 			"Sets the background color of the box containing the layout text.\n"
 		"  --layout-border-color <color>    "
@@ -662,6 +684,8 @@ static int parse_options(int argc, char **argv, struct swaylock_state *state,
 			"Sets the color of the text when verifying.\n"
 		"  --text-wrong-color <color>       "
 			"Sets the color of the text when invalid.\n"
+		"  --show-keypad                    "
+			"Enable on-screen keyboard.\n"
 		"\n"
 		"All <color> options are of the form <rrggbb[aa]>.\n";
 
@@ -848,6 +872,11 @@ static int parse_options(int argc, char **argv, struct swaylock_state *state,
 				state->args.colors.key_highlight = parse_color(optarg);
 			}
 			break;
+		case LO_KEYPAD_TEXT_COLOR:
+			if (state) {
+				state->args.colors.keypad_text = parse_color(optarg);
+			}
+			break;
 		case LO_LAYOUT_BG_COLOR:
 			if (state) {
 				state->args.colors.layout_background = parse_color(optarg);
@@ -941,6 +970,11 @@ static int parse_options(int argc, char **argv, struct swaylock_state *state,
 		case LO_TEXT_WRONG_COLOR:
 			if (state) {
 				state->args.colors.text.wrong = parse_color(optarg);
+			}
+			break;
+		case LO_SHOW_KEYPAD:
+			if (state) {
+				state->args.show_keypad = true;
 			}
 			break;
 		default:
@@ -1112,6 +1146,7 @@ int main(int argc, char **argv) {
 		.hide_keyboard_layout = false,
 		.show_failed_attempts = false,
 		.indicator_idle_visible = false,
+		.show_keypad = false,
 		.ready_fd = -1,
 	};
 	wl_list_init(&state.images);

--- a/password.c
+++ b/password.c
@@ -215,3 +215,28 @@ void swaylock_handle_key(struct swaylock_state *state,
 		break;
 	}
 }
+
+void swaylock_handle_keypad_key(struct swaylock_state *state, const char *key) {
+	if (key == NULL || key[0] == '\0') {
+		return;
+	}
+
+	if (strcmp(key, "Go") == 0) {
+		swaylock_handle_key(state, XKB_KEY_Return, 0);
+		return;
+	}
+	if (strcmp(key, "Del") == 0) {
+		swaylock_handle_key(state, XKB_KEY_BackSpace, 0);
+		return;
+	}
+	if (strcmp(key, "Alt") == 0) {
+		state->keypad_upper = !state->keypad_upper;
+		damage_state(state);
+		return;
+	}
+
+	uint32_t codepoint = (unsigned char)key[0];
+	if (codepoint != 0) {
+		swaylock_handle_key(state, XKB_KEY_NoSymbol, codepoint);
+	}
+}

--- a/render.c
+++ b/render.c
@@ -4,6 +4,7 @@
 #include <wayland-client.h>
 #include "cairo.h"
 #include "background-image.h"
+#include "keypad_layout.h"
 #include "swaylock.h"
 #include "log.h"
 
@@ -48,6 +49,7 @@ static const struct wl_callback_listener surface_frame_listener = {
 };
 
 static bool render_frame(struct swaylock_surface *surface);
+static bool render_keypad_frame(struct swaylock_surface *surface);
 
 void render(struct swaylock_surface *surface) {
 	struct swaylock_state *state = surface->state;
@@ -103,6 +105,7 @@ void render(struct swaylock_surface *surface) {
 	wl_surface_set_buffer_scale(surface->surface, surface->scale);
 
 	render_frame(surface);
+	render_keypad_frame(surface);
 	surface->dirty = false;
 	surface->frame = wl_surface_frame(surface->surface);
 	wl_callback_add_listener(surface->frame, &surface_frame_listener, surface);
@@ -397,5 +400,78 @@ static bool render_frame(struct swaylock_surface *surface) {
 	wl_surface_damage_buffer(surface->child, 0, 0, INT32_MAX, INT32_MAX);
 	wl_surface_commit(surface->child);
 
+	return true;
+}
+
+static void draw_key_label(cairo_t *cairo, const char *label,
+		double x, double y, double w, double h) {
+	cairo_text_extents_t ext;
+	cairo_font_extents_t fe;
+	cairo_text_extents(cairo, label, &ext);
+	cairo_font_extents(cairo, &fe);
+	double tx = x + (w / 2.0) - (ext.width / 2.0 + ext.x_bearing);
+	double ty = y + (h / 2.0) + (fe.height / 2.0 - fe.descent);
+	cairo_move_to(cairo, tx, ty);
+	cairo_show_text(cairo, label);
+}
+
+static bool render_keypad_frame(struct swaylock_surface *surface) {
+	struct swaylock_state *state = surface->state;
+	if (!state->args.show_keypad) {
+		wl_surface_attach(surface->keypad_child, NULL, 0, 0);
+		wl_surface_commit(surface->keypad_child);
+		return true;
+	}
+
+	const double spacing = 6.0;
+	const int key_h = 42;
+	int keypad_w = surface->width;
+	int keypad_h = (int)(KEYPAD_ROWS * key_h + (KEYPAD_ROWS + 1) * spacing);
+	double key_w = ((double)keypad_w - ((KEYPAD_COLS + 1) * spacing)) / KEYPAD_COLS;
+
+	surface->keypad_width = keypad_w;
+	surface->keypad_height = keypad_h;
+	surface->keypad_x = 0;
+	surface->keypad_y = surface->height - keypad_h;
+
+	int buffer_width = keypad_w * surface->scale;
+	int buffer_height = keypad_h * surface->scale;
+	struct pool_buffer *buffer = get_next_buffer(state->shm, surface->keypad_buffers,
+		buffer_width, buffer_height);
+	if (buffer == NULL) {
+		return false;
+	}
+
+	cairo_t *cairo = buffer->cairo;
+	cairo_set_antialias(cairo, CAIRO_ANTIALIAS_BEST);
+	cairo_identity_matrix(cairo);
+	cairo_save(cairo);
+	cairo_set_source_rgba(cairo, 0, 0, 0, 0);
+	cairo_set_operator(cairo, CAIRO_OPERATOR_SOURCE);
+	cairo_paint(cairo);
+	cairo_restore(cairo);
+	cairo_scale(cairo, surface->scale, surface->scale);
+	configure_font_drawing(cairo, state, surface->subpixel, state->args.radius);
+
+	const char *(*layout)[KEYPAD_COLS] = state->keypad_upper ?
+		keypad_layout_upper : keypad_layout_base;
+	for (int row = 0; row < KEYPAD_ROWS; ++row) {
+		for (int col = 0; col < KEYPAD_COLS; ++col) {
+			const char *label = layout[row][col];
+			if (label[0] == '\0') {
+				continue;
+			}
+			double x = spacing + col * (key_w + spacing);
+			double y = spacing + row * (key_h + spacing);
+			cairo_set_source_u32(cairo, state->args.colors.keypad_text);
+			draw_key_label(cairo, label, x, y, key_w, key_h);
+		}
+	}
+
+	wl_subsurface_set_position(surface->keypad_subsurface, surface->keypad_x, surface->keypad_y);
+	wl_surface_set_buffer_scale(surface->keypad_child, surface->scale);
+	wl_surface_attach(surface->keypad_child, buffer->buffer, 0, 0);
+	wl_surface_damage_buffer(surface->keypad_child, 0, 0, INT32_MAX, INT32_MAX);
+	wl_surface_commit(surface->keypad_child);
 	return true;
 }

--- a/seat.c
+++ b/seat.c
@@ -2,11 +2,13 @@
 #include <stdlib.h>
 #include <sys/mman.h>
 #include <unistd.h>
+#include <linux/input-event-codes.h>
 #include <xkbcommon/xkbcommon.h>
 #include "log.h"
 #include "swaylock.h"
 #include "seat.h"
 #include "loop.h"
+#include "keypad_layout.h"
 
 static void keyboard_keymap(void *data, struct wl_keyboard *wl_keyboard,
 		uint32_t format, int32_t fd, uint32_t size) {
@@ -138,25 +140,66 @@ static const struct wl_keyboard_listener keyboard_listener = {
 	.repeat_info = keyboard_repeat_info,
 };
 
+static struct swaylock_surface *surface_for_wl_surface(
+		struct swaylock_state *state, struct wl_surface *wl_surface) {
+	struct swaylock_surface *surface;
+	wl_list_for_each(surface, &state->surfaces, link) {
+		if (wl_surface == surface->surface ||
+				wl_surface == surface->child ||
+				wl_surface == surface->keypad_child) {
+			return surface;
+		}
+	}
+	return NULL;
+}
+
 static void wl_pointer_enter(void *data, struct wl_pointer *wl_pointer,
 		uint32_t serial, struct wl_surface *surface,
 		wl_fixed_t surface_x, wl_fixed_t surface_y) {
+	struct swaylock_seat *seat = data;
+	seat->pointer_wl_surface = surface;
+	seat->pointer_surface = surface_for_wl_surface(seat->state, surface);
+	seat->pointer_x = wl_fixed_to_double(surface_x);
+	seat->pointer_y = wl_fixed_to_double(surface_y);
 	wl_pointer_set_cursor(wl_pointer, serial, NULL, 0, 0);
 }
 
 static void wl_pointer_leave(void *data, struct wl_pointer *wl_pointer,
 		uint32_t serial, struct wl_surface *surface) {
 	// Who cares
+	struct swaylock_seat *seat = data;
+	seat->pointer_wl_surface = NULL;
+	seat->pointer_surface = NULL;
 }
 
 static void wl_pointer_motion(void *data, struct wl_pointer *wl_pointer,
 		uint32_t time, wl_fixed_t surface_x, wl_fixed_t surface_y) {
 	// Who cares
+	struct swaylock_seat *seat = data;
+	seat->pointer_x = wl_fixed_to_double(surface_x);
+	seat->pointer_y = wl_fixed_to_double(surface_y);
 }
 
 static void wl_pointer_button(void *data, struct wl_pointer *wl_pointer,
 		uint32_t serial, uint32_t time, uint32_t button, uint32_t state) {
 	// Who cares
+	struct swaylock_seat *seat = data;
+	if (state != WL_POINTER_BUTTON_STATE_PRESSED || button != BTN_LEFT) {
+		return;
+	}
+	if (seat->pointer_surface == NULL) {
+		return;
+	}
+	double x = seat->pointer_x;
+	double y = seat->pointer_y;
+	if (seat->pointer_wl_surface == seat->pointer_surface->child) {
+		return;
+	}
+	if (seat->pointer_wl_surface == seat->pointer_surface->keypad_child) {
+		x += seat->pointer_surface->keypad_x;
+		y += seat->pointer_surface->keypad_y;
+	}
+	swaylock_handle_pointer_click(seat->state, seat->pointer_surface, x, y);
 }
 
 static void wl_pointer_axis(void *data, struct wl_pointer *wl_pointer,
@@ -208,12 +251,43 @@ static void seat_handle_capabilities(void *data, struct wl_seat *wl_seat,
 	}
 	if ((caps & WL_SEAT_CAPABILITY_POINTER)) {
 		seat->pointer = wl_seat_get_pointer(wl_seat);
-		wl_pointer_add_listener(seat->pointer, &pointer_listener, NULL);
+		wl_pointer_add_listener(seat->pointer, &pointer_listener, seat);
 	}
 	if ((caps & WL_SEAT_CAPABILITY_KEYBOARD)) {
 		seat->keyboard = wl_seat_get_keyboard(wl_seat);
 		wl_keyboard_add_listener(seat->keyboard, &keyboard_listener, seat);
 	}
+}
+
+static bool point_in_rect(double x, double y, int32_t rx, int32_t ry,
+		uint32_t rw, uint32_t rh) {
+	return x >= rx && y >= ry && x < (double)rx + rw && y < (double)ry + rh;
+}
+
+void swaylock_handle_pointer_click(struct swaylock_state *state,
+		struct swaylock_surface *surface, double x, double y) {
+	if (!state->args.show_keypad) {
+		return;
+	}
+	if (!point_in_rect(x, y, surface->keypad_x, surface->keypad_y,
+			surface->keypad_width, surface->keypad_height)) {
+		return;
+	}
+
+	double local_x = x - surface->keypad_x;
+	double local_y = y - surface->keypad_y;
+	double cell_w = (double)surface->keypad_width / KEYPAD_COLS;
+	double cell_h = (double)surface->keypad_height / KEYPAD_ROWS;
+	int col = local_x / cell_w;
+	int row = local_y / cell_h;
+
+	if (row < 0 || row >= KEYPAD_ROWS || col < 0 || col >= KEYPAD_COLS) {
+		return;
+	}
+
+	const char *key = state->keypad_upper ?
+		keypad_layout_upper[row][col] : keypad_layout_base[row][col];
+	swaylock_handle_keypad_key(state, key);
 }
 
 static void seat_handle_name(void *data, struct wl_seat *wl_seat,


### PR DESCRIPTION
this implement an on screen keyboard for tablet or cellphone.
add a parameter --show-keypad for enabling this feature and --keypad-text-color for setting color

This feature has been requested repeatedly for several times in #394 #271 #426 
