### PR TITLE
main: fix reversed dup2 arguments in daemonize

### DIFF
--- a/main.c
+++ b/main.c
@@ -66,8 +66,8 @@ static void daemonize(void) {
 		setsid();
 		close(fds[0]);
 		int devnull = open("/dev/null", O_RDWR);
-		dup2(STDOUT_FILENO, devnull);
-		dup2(STDERR_FILENO, devnull);
+		dup2(devnull, STDOUT_FILENO);
+		dup2(devnull, STDERR_FILENO);
 		close(devnull);
 		uint8_t success = 0;
 		if (chdir("/") != 0) {


### PR DESCRIPTION
## Problem

`daemonize()` opens `/dev/null` and tries to redirect the daemon's stdout and
stderr into it, but the `dup2()` arguments are reversed:

```c
int devnull = open("/dev/null", O_RDWR);
dup2(STDOUT_FILENO, devnull);
dup2(STDERR_FILENO, devnull);
close(devnull);
```

`dup2(oldfd, newfd)` duplicates `oldfd` onto `newfd`. Here `newfd` is the
freshly opened `/dev/null` descriptor, so the two calls just overwrite that
descriptor with copies of stdout/stderr and then `close()` it. Descriptors 1
and 2 are never touched — the daemon's stdout and stderr stay attached to the
controlling terminal instead of `/dev/null`.

As a result, when swaylock is run with `-f`/`--daemonize`, output written to
stdout/stderr by the backgrounded process leaks to the terminal rather than
being discarded as intended.

## Fix

Swap the arguments so `/dev/null` is duplicated onto `STDOUT_FILENO` and
`STDERR_FILENO`:

```c
dup2(devnull, STDOUT_FILENO);
dup2(devnull, STDERR_FILENO);
```

Two-line change, no behaviour change beyond the intended redirect. Builds
cleanly with meson/ninja.
